### PR TITLE
Updated overall diagram: there was a wrong dependency

### DIFF
--- a/diagrams/VCWG_specifications.drawio
+++ b/diagrams/VCWG_specifications.drawio
@@ -1,4 +1,4 @@
-<mxfile host="Electron" modified="2024-05-13T12:33:46.570Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/24.2.5 Chrome/120.0.6099.109 Electron/28.1.0 Safari/537.36" etag="y1elp4czJp4sql-Zs_SG" version="24.2.5" type="device">
+<mxfile host="Electron" modified="2024-05-27T07:32:24.104Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/24.4.8 Chrome/124.0.6367.207 Electron/30.0.6 Safari/537.36" etag="bP6F8sYsIe1ue5Vl5IPq" version="24.4.8" type="device">
   <diagram name="Page-1" id="6gULVhWcurzz5zKnDaAR">
     <mxGraphModel dx="1600" dy="1216" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
       <root>
@@ -92,11 +92,11 @@
         <mxCell id="r7VOtmBWi9sTdI5Oyx6i-46" value="&lt;i style=&quot;border-color: var(--border-color); color: rgb(0, 0, 0); font-family: Helvetica; font-size: 16px; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(251, 251, 251); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;&quot;&gt;Embedded proofs&lt;/i&gt;" style="text;whiteSpace=wrap;html=1;fontSize=16;align=center;rounded=1;labelBackgroundColor=none;" parent="1" vertex="1">
           <mxGeometry x="266.505" y="650" width="220" height="40" as="geometry" />
         </mxCell>
-        <mxCell id="Xbw9OttzSYU2m0TrLEde-5" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;fontSize=12;startSize=8;endSize=8;" edge="1" parent="1" source="Xbw9OttzSYU2m0TrLEde-2" target="r7VOtmBWi9sTdI5Oyx6i-1">
+        <mxCell id="Xbw9OttzSYU2m0TrLEde-5" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;fontSize=12;startSize=8;endSize=8;startArrow=classic;startFill=1;endArrow=none;endFill=0;" parent="1" source="Xbw9OttzSYU2m0TrLEde-2" target="r7VOtmBWi9sTdI5Oyx6i-1" edge="1">
           <mxGeometry relative="1" as="geometry" />
         </mxCell>
         <UserObject label="&lt;font style=&quot;&quot;&gt;&lt;span style=&quot;font-size: 20px;&quot;&gt;Controller Documents&lt;/span&gt;&lt;/font&gt;&lt;div&gt;&lt;font style=&quot;&quot;&gt;&lt;i style=&quot;font-size: 10px;&quot;&gt;Common definitions for verification methods and relationships&lt;/i&gt;&lt;br&gt;&lt;/font&gt;&lt;/div&gt;" link="https://www.w3.org/TR/controller-document/" linkTarget="_blank" id="Xbw9OttzSYU2m0TrLEde-2">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;labelBackgroundColor=none;fillColor=none;" vertex="1" parent="1">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;labelBackgroundColor=none;fillColor=none;" parent="1" vertex="1">
             <mxGeometry x="426.26" y="195" width="237.5" height="70" as="geometry" />
           </mxCell>
         </UserObject>
@@ -133,7 +133,7 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="Xbw9OttzSYU2m0TrLEde-3" value="" style="edgeStyle=elbowEdgeStyle;elbow=vertical;endArrow=classic;html=1;curved=0;rounded=1;endSize=8;startSize=8;fontSize=12;exitX=0.25;exitY=0;exitDx=0;exitDy=0;entryX=0.75;entryY=1;entryDx=0;entryDy=0;labelBackgroundColor=none;fontColor=default;" edge="1" parent="1" source="r7VOtmBWi9sTdI5Oyx6i-6" target="Xbw9OttzSYU2m0TrLEde-2">
+        <mxCell id="Xbw9OttzSYU2m0TrLEde-3" value="" style="edgeStyle=elbowEdgeStyle;elbow=vertical;endArrow=classic;html=1;curved=0;rounded=1;endSize=8;startSize=8;fontSize=12;exitX=0.25;exitY=0;exitDx=0;exitDy=0;entryX=0.75;entryY=1;entryDx=0;entryDy=0;labelBackgroundColor=none;fontColor=default;" parent="1" source="r7VOtmBWi9sTdI5Oyx6i-6" target="Xbw9OttzSYU2m0TrLEde-2" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="759" y="366" as="sourcePoint" />
             <mxPoint x="720" y="130" as="targetPoint" />
@@ -142,7 +142,7 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="Xbw9OttzSYU2m0TrLEde-4" value="" style="edgeStyle=elbowEdgeStyle;elbow=vertical;endArrow=classic;html=1;curved=0;rounded=1;endSize=8;startSize=8;fontSize=12;exitX=0.75;exitY=0;exitDx=0;exitDy=0;entryX=0.25;entryY=1;entryDx=0;entryDy=0;labelBackgroundColor=none;fontColor=default;" edge="1" parent="1" source="r7VOtmBWi9sTdI5Oyx6i-2" target="Xbw9OttzSYU2m0TrLEde-2">
+        <mxCell id="Xbw9OttzSYU2m0TrLEde-4" value="" style="edgeStyle=elbowEdgeStyle;elbow=vertical;endArrow=classic;html=1;curved=0;rounded=1;endSize=8;startSize=8;fontSize=12;exitX=0.75;exitY=0;exitDx=0;exitDy=0;entryX=0.25;entryY=1;entryDx=0;entryDy=0;labelBackgroundColor=none;fontColor=default;" parent="1" source="r7VOtmBWi9sTdI5Oyx6i-2" target="Xbw9OttzSYU2m0TrLEde-2" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="530" y="360" as="sourcePoint" />
             <mxPoint x="470" y="280" as="targetPoint" />

--- a/diagrams/VCWG_specifications.svg
+++ b/diagrams/VCWG_specifications.svg
@@ -186,8 +186,8 @@
         <text xmlns="http://www.w3.org/2000/svg" x="322" y="629" font-family="Helvetica" font-size="16" text-anchor="middle">Embedded proofs</text>
     </switch>
     <g stroke="#000" stroke-miterlimit="10">
-        <path fill="none" d="m490.01 151-.22-43.13" pointer-events="stroke"/>
-        <path d="m489.76 101.12 4.55 8.98-4.52-2.23-4.48 2.27Z" pointer-events="all"/>
+        <path fill="none" d="m489.97 143.13-.21-43.13" pointer-events="stroke"/>
+        <path d="m490 149.88-4.54-8.98 4.51 2.23 4.49-2.27Z" pointer-events="all"/>
     </g>
     <a xlink:href="https://www.w3.org/TR/controller-document/" target="_blank">
         <rect width="237.5" height="70" x="371.26" y="151" fill="none" stroke="#000" pointer-events="all" rx="10.5" ry="10.5"/>

--- a/index.html
+++ b/index.html
@@ -126,15 +126,6 @@
         alternateFormats: [ {uri: "diff-20111214.html", label: "diff to previous version"} ],
         */
         localBiblio: {
-          "CONTROLLER-DOCUMENT": {
-            title: "Controller Documents 1.0",
-            date: "May 2024",
-            href: "https://www.w3.org/TR/controller-document/",
-            authors: [
-              "Many Sporny",
-              "Michael B. Jones"
-            ]
-          },
           "MULTIBASE": {
             title: "The Multibase Data Format",
             date: "February 2023",


### PR DESCRIPTION
The Controller Document does not depend on the VCDM; the inverse is true. The arrow line has been updated accordingly.

(In passing, the explicit bibliography entry to the Controller Document has been removed; it is now in spec-ref)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-overview/pull/9.html" title="Last updated on May 27, 2024, 7:38 AM UTC (30df2fa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-overview/9/2cfe8f8...30df2fa.html" title="Last updated on May 27, 2024, 7:38 AM UTC (30df2fa)">Diff</a>