### PR TITLE
Putting an explicit version (for now) for respec-vc

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
       out in the same tree and use relative links so that they'll work offline,
      -->
     <script src='https://www.w3.org/Tools/respec/respec-w3c' class='remove'></script>
-    <script class="remove" src="https://cdn.jsdelivr.net/gh/w3c/respec-vc/dist/main.js"></script>
+    <script class="remove" src="https://cdn.jsdelivr.net/gh/w3c/respec-vc@3.3.2/dist/main.js"></script>
     
     <script type="text/javascript" class="remove">
       var respecConfig = {


### PR DESCRIPTION
Adding this to force regeneration with the right version


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-overview/pull/12.html" title="Last updated on Jul 5, 2024, 3:16 PM UTC (7caca2b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-overview/12/b82ac07...7caca2b.html" title="Last updated on Jul 5, 2024, 3:16 PM UTC (7caca2b)">Diff</a>