### PR TITLE
Using the CID-1.0 reference everywhere

### DIFF
--- a/index.html
+++ b/index.html
@@ -121,16 +121,6 @@
         alternateFormats: [ {uri: "diff-20111214.html", label: "diff to previous version"} ],
         */
         localBiblio: {
-          "CID-1.0": {
-            title: "Controlled Identifiers 1.0",
-            href: "https://www.w3.org/TR/cid-1.0/",
-            authors: [
-              "Manu Sporny",
-              "Michael B. Jones"
-            ],
-            status: "W3C Working Draft",
-            publisher: "Verifiable Credentials Working Group"
-          },
           "MULTIBASE": {
             title: "The Multibase Data Format",
             date: "February 2023",
@@ -311,8 +301,8 @@
         </p>
 
         <p>
-          Finally, the Controlled Identifiers [[CONTROLLER-DOCUMENT]] specification defines some common terms (e.g., verification <a href="https://www.w3.org/TR/cid-1.0/#verification-relationships">relationships</a> and
-          <a href="https://www.w3.org/TR//controller-document/#dfn-verification-method">methods</a>) that are used not only by other Verifiable Credential specifications, but also other Recommendations such as [[[DID-CORE]]] [[DID-CORE]].
+          Finally, the [[[CID-1.0]]] [[CID-1.0]] specification defines some common terms (e.g., verification <a data-cite="CID-1.0#verification-relationships">relationships</a> and
+          <a data-cite="CID-1.0#dfn-verification-method">methods</a>) that are used not only by other Verifiable Credential specifications, but also other Recommendations such as [[[DID-CORE]]] [[DID-CORE]].
         </p>
 
         <figure id="overall">
@@ -849,7 +839,7 @@
             The <a data-cite="VC-DATA-INTEGRITY#proofs">definition of `proof`</a> introduces a number of additional properties. 
             Some of these are metadata properties on the proof itself, like `created`, `expires`, or `domain`. 
             Others provide the necessary details on the proof generation process itself, like `cryptosuite`, `nonce` (if needed), or `verificationMethod` that usually refers to cryptographic keys.
-            The exact format of the public keys, when used for Credentials, is defined in the [[CONTROLLER-DOCUMENT]] specification, and is based on either the JWK [[RFC7517]] format or a <a data-cite="CONTROLLER-DOCUMENT#multibase-0">Multibase</a> encoding of the keys, called <a data-cite="CONTROLLER-DOCUMENT#multikey">Multikey</a>.
+            The exact format of the public keys, when used for Credentials, is defined in the [[CID-1.0]] specification, and is based on either the JWK [[RFC7517]] format or a <a data-cite="CID-1.0#multibase-0">Multibase</a> encoding of the keys, called <a data-cite="CID-1.0#multikey">Multikey</a>.
             Details of the key values are defined by other communities (IETF, cryptography groups, etc.) and are dependent on the specific cryptographic functions they operate with.
           </p>
 
@@ -860,7 +850,7 @@
 
           <p>
             A proof may also specify its "purpose" via the `proofPurpose` property: different proofs may be provided for authentication, for assertion, or for key agreement protocols.
-            These are defined in the [[CONTROLLER-DOCUMENT]] specification.
+            These are defined in the [[CID-1.0]] specification.
             The verifier is supposed to choose the right proof depending on the purpose of its own operations, which is yet another possible reasons why the holder or the issuer may provide several proofs for the same Credential.
           </p>
 
@@ -892,7 +882,7 @@
 
 
           <p class="note">
-            A common characteristic of all these cryptosuites is that keys must always be encoded using the <a data-cite="CONTROLLER-DOCUMENT#multikey">Multikey</a> encoding.
+            A common characteristic of all these cryptosuites is that keys must always be encoded using the <a data-cite="CID-1.0#multikey">Multikey</a> encoding.
             For the ECDSA case the keys may also carry the choice of the hash functions to be used by the proof generation algorithm. 
             This provides yet another differentiation axis among cryptosuites.
           </p>


### PR DESCRIPTION
Now that CID-1.0 is the official reference...


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-overview/pull/22.html" title="Last updated on Feb 4, 2025, 3:27 PM UTC (8d383d2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-overview/22/6d38dff...8d383d2.html" title="Last updated on Feb 4, 2025, 3:27 PM UTC (8d383d2)">Diff</a>