### PR TITLE
Sync with REC publication

### DIFF
--- a/index.html
+++ b/index.html
@@ -284,9 +284,9 @@
         <div class="note">
           <p>
             As of May 2025, all but two of these documents have been published as W3C "Recommendations", which is the W3C terminology for Web Standards.
-            The two exceptions are the [[[VC-JSON-SCHEMA]]] and the [[[VC-DI-BBS]]] specifications: though technically complete, they are still "Candidate" Recommendations. 
+            The two exceptions are the [[[VC-JSON-SCHEMA]]] and the [[[VC-DI-BBS]]] specifications; though technically complete, they are still "Candidate" Recommendations. 
             The reasons are different. The former has not yet been implemented by at least two mutually independent implementations (which is the requirement to be published as standards) whereas the latter has to wait until the underlying cryptographic technique (i.e., [[[CFRG-BBS-SIGNATURE]]]) is finalized by the IETF. 
-            It is to be expected that these two documents will be published as Web Standards soon.
+            It is expected that these two documents will be published as Web Standards soon.
           </p>
 
         </div>
@@ -663,7 +663,7 @@
           The usage of COSE [[RFC9052]] is similar to JOSE, except that all structures are represented in CBOR [[RFC8949]].
           From the Credentials point of view, however, the structure is similar insofar as the Credential (or the Presentation)
           is again the payload for COSE.
-          The usage of CBOR means that the final representation of the Verifiable Credential (or Presentation) may have a significantly reduced footprint which can be, for example, shown in a QR Code.
+          The use of CBOR means that the final representation of the Verifiable Credential (or Presentation) can have a significantly reduced footprint which can be, for example, shown in a QR Code.
         </p>
         
         <p>
@@ -846,8 +846,8 @@
           <p>
             <a href="#cryptosuites-diagram"></a> provides an overall view of the six cryptosuites defined by the three recommendations.
             They all implement the general pipeline of proof generation as described in <a href="#proof-generation-steps">section 4.2.1</a>.
-            As shown on the figure, one axes of differentiation is the data transformation function, i.e., the canonicalization of the JSON serialization: two cryptosuites use JSON Canonicalization (JCS) [[RFC8785]], the other four use RDF Dataset Canonicalization (RDFC-1.0) [[RDF-CANON]].
-            The other axis is whether the cryptosuite provides selective disclosure, which is the case for two out of the six
+            As shown on the figure, one axis of differentiation is the data transformation function, i.e., the canonicalization of the JSON serialization: two cryptosuites use JSON Canonicalization (JCS) [[RFC8785]], while the other four use RDF Dataset Canonicalization (RDFC-1.0) [[RDF-CANON]].
+            The other axis is whether the cryptosuite provides selective disclosure, which is the case for two of the six
             cryptosuites.
           </p>
 
@@ -866,7 +866,7 @@
           </p>
 
           <p class="note">
-            Applications may define their own cryptosuites by using similar patterns using a different transformation or cryptographic signature scheme. 
+            Applications may define their own cryptosuites by applying different transformation and/or cryptographic signature schemes in similar patterns.
             For example, it would be possible to define a cryptosuite using the SM2 algorithm [[RFC9563]] instead of, say, EdDSA.
           </p>
 
@@ -911,9 +911,9 @@
             </p>
 
             <p> 
-              The verifier should be in position to trust the proof of the reveal document without having access to the original data and its (base) proof.
-              In the `ecdsa-sd-2023` case, each non-mandatory claim is signed separately by the issuer using a common, ephemeral ECDSA secret key, whose public counterpart is part of the both the base and derived proof values. That can be used to check the disclosed non-mandatory claims.
-              The `bbs-2023` case relies on the cryptographic properties of the BBS scheme itself, which support the creation of proofs for the verification of selectively disclosed data. 
+              The verifier should able to test the proof of the reveal document without having access to the original data and its (base) proof.
+              With `ecdsa-sd-2023`, each non-mandatory claim is signed separately by the issuer using a common, ephemeral ECDSA secret key, whose public counterpart is part of the both the base and derived proof values. That can be used to check the disclosed non-mandatory claims.
+              The `bbs-2023` cryptosuite relies on the cryptographic properties of the BBS scheme itself, which support the creation of proofs for the verification of selectively disclosed data.
               This is based on the mathematical nature of the BBS scheme: the <em>BBS signature</em> of all the claims (generated by the issuer and part of the base proof) can be reused by the holder to generate a <em>BBS Proof</em> of the subset of the claims (which is part of the derived proof). The BBS specific verification step ensures the required trust.
             </p>
 
@@ -963,7 +963,7 @@
           </pre>
           
           <p>
-            When dereferenced, the URL value of the `verificationMethod` property should return a public key in Multikey format, for example:
+            When dereferenced, the URL value of the `verificationMethod` property should return a public key in Multikey format. For example:
           </p>
           
           <pre class="example nohighlight" title="An ECDSA public key">

--- a/index.html
+++ b/index.html
@@ -121,38 +121,6 @@
         alternateFormats: [ {uri: "diff-20111214.html", label: "diff to previous version"} ],
         */
         localBiblio: {
-          "MULTIBASE": {
-            title: "The Multibase Data Format",
-            date: "February 2023",
-            href: "https://datatracker.ietf.org/doc/draft-multiformats-multibase",
-            authors: [
-              "Juan Benet",
-              "Manu Sporny"
-            ],
-            status: "Internet-Draft",
-            publisher: "IETF"
-          },
-          "MULTIHASH": {
-            title: "The Multihash Data Format",
-            date: "February 2023",
-            href: "https://datatracker.ietf.org/doc/draft-multiformats-multihash",
-            authors: [
-              "Juan Benet",
-              "Manu Sporny"
-            ],
-            status: "Internet-Draft",
-            publisher: "IETF"
-          },
-          "MULTICODEC": {
-            title: "The Multi Codec Encoding Scheme",
-            date: "February 2022",
-            href: "https://github.com/multiformats/multicodec/blob/master/table.csv",
-            authors: [
-              "The Multiformats Community"
-            ],
-            status: "Internet-Draft",
-            publisher: "IETF"
-          },
           "SD-JWT": {
             title: "Selective Disclosure for JWTs (SD-JWT)",
             href: "https://datatracker.ietf.org/doc/draft-ietf-oauth-selective-disclosure-jwt/",
@@ -292,7 +260,7 @@
 
         <p>
           The general structure for embedded proofs is defined in a separate [[[VC-DATA-INTEGRITY]]] [[VC-DATA-INTEGRITY]] specification.
-          Furthermore, the Working Group also specifies some instances of this general structure in the form of the "cryptosuites": [[[VC-DI-EDDSA]]] [[VC-DI-EDDSA]], [[[VC-DI-ECDSA]]] [[VC-DI-ECDSA]], and [[[VC-DI-BBS]]] [[VC-DI-BBS]]. 
+          The Working Group also specifies some instances of this general structure in the form of the "cryptosuites": [[[VC-DI-EDDSA]]] [[VC-DI-EDDSA]], [[[VC-DI-ECDSA]]] [[VC-DI-ECDSA]], and [[[VC-DI-BBS]]] [[VC-DI-BBS]]. 
           Other cryptosuites may be specified by the community.
         </p>
 
@@ -312,6 +280,16 @@
             Verifiable Credentials Working Group Recommendations
           </figcaption>
         </figure>
+
+        <div class="note">
+          <p>
+            As of May 2025, all but two of these documents have been published as W3C "Recommendations", which is the W3C terminology for Web Standards.
+            The two exceptions are the [[[VC-JSON-SCHEMA]]] and the [[[VC-DI-BBS]]] specifications: though technically complete, they are still "Candidate" Recommendations. 
+            The reasons are different. The former has not yet been implemented by at least two mutually independent implementations (which is the requirement to be published as standards) whereas the latter has to wait until the underlying cryptographic technique (i.e., [[[CFRG-BBS-SIGNATURE]]]) is finalized by the IETF. 
+            It is to be expected that these two documents will be published as Web Standards soon.
+          </p>
+
+        </div>
       </section>
     </section>
 
@@ -381,7 +359,7 @@
           <p>
             Claims are expressed using "properties" referring to "values".
             Values may be literals, but may also be other entities referred to, usually, by a [[URL]]. 
-            It that case, the entity may become the subject of another claim; these claims, together, form a "graph" of claims that represents a Credential.
+            It that case, that entity may become the subject of another claim; these claims, together, form a "graph" of claims that represents a Credential.
             (See <a href="#credential-example-claims"></a> for an example of such a graph represented graphically. 
             For more complex examples, refer to the [[[VC-DATA-MODEL-2.0]]] specification itself.)
           </p>
@@ -474,7 +452,7 @@
         <p>
           The following JSON-LD code is an example for a simple Credential. It states that the person named "Pat", identified by <code>https://www.exampl.org/persons/pat</code>, is an alumni of the Example University (identified by <code>did:example:c276e12ec21ebfeb1f712ebc6f1</code>).
           The Credential is valid from the 1st of January 2010, and is issued by an entity identified by <code>did:example:2g55q912ec3476eba2l9812ecbfe</code>.
-          Most of the properties in the Credential are from the standard Verifiable Credentials vocabulary, but some terms (like `alumniOf`, `AlumniCredential`) are added by the application-specific vocabulary referred to by <code>https://www.w3.org/ns/credentials/examples/v2</code>.
+          Most of the properties in the Credential are from the standard Verifiable Credentials vocabulary (identified by <code>https://www.w3.org/ns/credentials/v2</code>), but some terms (like `alumniOf`, `AlumniCredential`) are added by the application-specific vocabulary referred to by <code>https://www.w3.org/ns/credentials/examples/v2</code>.
         </p>
 
         <pre id="base_example" class="example nohighlight" title="A Simple Credential">
@@ -685,7 +663,7 @@
           The usage of COSE [[RFC9052]] is similar to JOSE, except that all structures are represented in CBOR [[RFC8949]].
           From the Credentials point of view, however, the structure is similar insofar as the Credential (or the Presentation)
           is again the payload for COSE.
-          The usage of CBOR means that the final representation of the Verifiable Credential (or Presentation) has a significantly reduced footprint which can be, for example, shown in a QR Code.
+          The usage of CBOR means that the final representation of the Verifiable Credential (or Presentation) may have a significantly reduced footprint which can be, for example, shown in a QR Code.
         </p>
         
         <p>
@@ -785,13 +763,13 @@
           <h4>Data Integrity of Credentials</h4>
 
           <p>
-            The [[[VC-DATA-INTEGRITY]]] [[VC-DATA-INTEGRITY]] specification relies on the general structure and defines a set of standard properties describing the details of the proof generation process.
-            The specific details (canonicalization algorithm, hash and/or proof method algorithms, etc.) are defined by separate <em>cryptosuites</em>. 
+            The [[[VC-DATA-INTEGRITY]]] [[VC-DATA-INTEGRITY]] specification starts with the general structure and defines a set of standard properties describing the details of the proof generation process.
+            The specific details (i.e., the transformation, hash, and/or proof method algorithms) are defined by separate <em>cryptosuites</em>. 
             The Working Group has defined a number of such cryptosuites as separate specifications, see <a href="#cryptosuites"></a> below.
           </p>
 
           <p>
-            The core property, in the general structure, is `proof`. 
+            The core property, in the general structure, is called `proof`. 
             This property embeds a claim in the Credential, referring to a separate collection of claims (referred to as a <em>Proof Graph</em>) detailing all the claims about the proof itself:
           </p>
 
@@ -850,7 +828,7 @@
 
           <p>
             A proof may also specify its "purpose" via the `proofPurpose` property: different proofs may be provided for authentication, for assertion, or for key agreement protocols.
-            These are defined in the [[CID-1.0]] specification.
+            These details are also defined in the [[CID-1.0]] specification.
             The verifier is supposed to choose the right proof depending on the purpose of its own operations, which is yet another possible reasons why the holder or the issuer may provide several proofs for the same Credential.
           </p>
 
@@ -861,15 +839,15 @@
           <h4>Cryptosuites</h4>
 
           <p>
-            The Working Group publishes three cryptosuite documents: [[[VC-DI-EDDSA]]] [[VC-DI-EDDSA]], [[[VC-DI-ECDSA]]] [[VC-DI-ECDSA]], and [[[VC-DI-BBS]]] [[VC-DI-BBS]]. 
+            The Working Group has published three cryptosuite documents: [[[VC-DI-EDDSA]]] [[VC-DI-EDDSA]], [[[VC-DI-ECDSA]]] [[VC-DI-ECDSA]], and [[[VC-DI-BBS]]] [[VC-DI-BBS]]. 
             As their name suggests, the documents rely on existing cryptographic signature schemes: the Edwards-Curve Digital Signature Algorithm (EdDSA) specification [[RFC8032]], the Elliptic Curve Digital Signature Algorithm (ECDSA) specification [[FIPS-186-5]], and the BBS Signature Scheme [[CFRG-BBS-SIGNATURE]], respectively.
           </p>
  
           <p>
             <a href="#cryptosuites-diagram"></a> provides an overall view of the six cryptosuites defined by the three recommendations.
             They all implement the general pipeline of proof generation as described in <a href="#proof-generation-steps">section 4.2.1</a>.
-            As shown on the figure, one axes of differentiation is the data transformation function, i.e., the canonicalization of the JSON serialization: two cryptosuites use JSON Canonicalization (JCS) [[RFC8785]], the others use RDF Dataset Canonicalization (RDFC-1.0) [[RDF-CANON]].
-            The other axis is whether the cryptosuite provides selective disclosure, which is the case for two of the six
+            As shown on the figure, one axes of differentiation is the data transformation function, i.e., the canonicalization of the JSON serialization: two cryptosuites use JSON Canonicalization (JCS) [[RFC8785]], the other four use RDF Dataset Canonicalization (RDFC-1.0) [[RDF-CANON]].
+            The other axis is whether the cryptosuite provides selective disclosure, which is the case for two out of the six
             cryptosuites.
           </p>
 
@@ -885,6 +863,11 @@
             A common characteristic of all these cryptosuites is that keys must always be encoded using the <a data-cite="CID-1.0#multikey">Multikey</a> encoding.
             For the ECDSA case the keys may also carry the choice of the hash functions to be used by the proof generation algorithm. 
             This provides yet another differentiation axis among cryptosuites.
+          </p>
+
+          <p class="note">
+            Applications may define their own cryptosuites by using similar patterns using a different transformation or cryptographic signature scheme. 
+            For example, it would be possible to define a cryptosuite using the SM2 algorithm [[RFC9563]] instead of, say, EdDSA.
           </p>
 
           <section>
@@ -930,7 +913,7 @@
             <p> 
               The verifier should be in position to trust the proof of the reveal document without having access to the original data and its (base) proof.
               In the `ecdsa-sd-2023` case, each non-mandatory claim is signed separately by the issuer using a common, ephemeral ECDSA secret key, whose public counterpart is part of the both the base and derived proof values. That can be used to check the disclosed non-mandatory claims.
-              The `bbs-2023` case relies on the cryptographic properties of the BBS scheme itself, which support the creation proofs for the verification of selectively disclosed data. 
+              The `bbs-2023` case relies on the cryptographic properties of the BBS scheme itself, which support the creation of proofs for the verification of selectively disclosed data. 
               This is based on the mathematical nature of the BBS scheme: the <em>BBS signature</em> of all the claims (generated by the issuer and part of the base proof) can be reused by the holder to generate a <em>BBS Proof</em> of the subset of the claims (which is part of the derived proof). The BBS specific verification step ensures the required trust.
             </p>
 
@@ -980,7 +963,7 @@
           </pre>
           
           <p>
-            When dereferenced, the URL `did:example:2g55q912ec3476eba2l9812ecbfe#ecdsa-public-key` should return an ECDSA public key in Multikey format, for example:
+            When dereferenced, the URL value of the `verificationMethod` property should return a public key in Multikey format, for example:
           </p>
           
           <pre class="example nohighlight" title="An ECDSA public key">
@@ -1008,7 +991,7 @@
       <!--MARK: Bitstrings -->
       <h2>Bitstring Status List</h2>
       <p>
-        It is often useful for an issuer of Verifiable Credentials to link to a location where a verifier can check to see if a credential has been suspended or revoked. 
+        It is often useful for an issuer of Verifiable Credentials to link to a location where a verifier can check whether a credential has been suspended or revoked. 
         This additional resource is referred to as a "status list".
       </p>    
       <p>
@@ -1140,12 +1123,12 @@
         <dl>
           <dt><a href="https://www.w3.org/2018/credentials/">Verifiable Credentials Vocabulary v2.0</a></dt>
           <dd>
-            Definition of property names defined, primarily, by the <a href="#s_vcdm">VC Data Model</a> specification, but with some terms defined by the <a href="#s_js_schema">VC JSON Schema</a> specification.
+            Definition of property names defined, primarily, by the <a href="#s_vcdm">VC Data Model</a> specification, with some terms defined by the <a href="#s_js_schema">VC JSON Schema</a> specification.
           </dd>
 
           <dt><a href="https://w3id.org/security">Security Vocabulary</a></dt>
           <dd>
-              Property name definitions in the <a href="#s_di">VC Data Integrity</a> specification or for the Controlled Identifiers.
+              Property name definitions in the <a href="#s_di">VC Data Integrity</a> and the Controlled Identifiers specifications.
           </dd>
 
           <dt><a href="https://www.w3.org/ns/credentials/status/">Bitstring Status List Vocabulary</a></dt>


### PR DESCRIPTION
Minor changes mostly related to the REC publication. Should only be merged once the RECs are published and specref is updated.

Details of the changes:

- added a note on the publication status of Recs and CRs
- pruned the bibliography in the header, removing unused entries
- minor editorial fixes and improvements in the text
- added a note on the possibility for applications to create their own cryptosuite, e.g., with SM2


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-overview/pull/24.html" title="Last updated on May 7, 2025, 9:01 AM UTC (6405bcd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-overview/24/3b5ad03...6405bcd.html" title="Last updated on May 7, 2025, 9:01 AM UTC (6405bcd)">Diff</a>