### PR TITLE
Adding a slightly darker background to the images in dark mode

### DIFF
--- a/diagrams/VCWG_specifications.drawio
+++ b/diagrams/VCWG_specifications.drawio
@@ -1,6 +1,6 @@
-<mxfile host="Electron" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/26.0.4 Chrome/128.0.6613.186 Electron/32.2.5 Safari/537.36" version="26.0.4">
+<mxfile host="Electron" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/26.2.15 Chrome/134.0.6998.205 Electron/35.2.1 Safari/537.36" version="26.2.15">
   <diagram name="Page-1" id="6gULVhWcurzz5zKnDaAR">
-    <mxGraphModel dx="1735" dy="1025" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" background="#FFFFFF" math="0" shadow="0">
+    <mxGraphModel dx="1667" dy="1058" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" background="none" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
@@ -25,9 +25,6 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="r7VOtmBWi9sTdI5Oyx6i-45" value="&lt;i style=&quot;border-color: var(--border-color); color: rgb(0, 0, 0); font-family: Helvetica; font-size: 16px; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(251, 251, 251); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;&quot;&gt;Securing mechanisms of VCs&lt;/i&gt;" style="text;whiteSpace=wrap;html=1;fontSize=16;align=center;rounded=1;labelBackgroundColor=none;" parent="1" vertex="1">
-          <mxGeometry x="435.005" y="702" width="220" height="40" as="geometry" />
-        </mxCell>
         <mxCell id="r7VOtmBWi9sTdI5Oyx6i-34" value="" style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;dashed=1;labelBackgroundColor=none;" parent="1" vertex="1">
           <mxGeometry x="565.005" y="340" width="310" height="340" as="geometry" />
         </mxCell>
@@ -36,9 +33,6 @@
             <mxGeometry x="605.005" y="360" width="237.5" height="50" as="geometry" />
           </mxCell>
         </UserObject>
-        <mxCell id="r7VOtmBWi9sTdI5Oyx6i-47" value="&lt;i style=&quot;border-color: var(--border-color); color: rgb(0, 0, 0); font-family: Helvetica; font-size: 16px; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(251, 251, 251); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;&quot;&gt;Enveloping proofs&lt;/i&gt;" style="text;whiteSpace=wrap;html=1;fontSize=16;align=center;rounded=1;labelBackgroundColor=none;strokeColor=none;" parent="1" vertex="1">
-          <mxGeometry x="613.755" y="650" width="220" height="40" as="geometry" />
-        </mxCell>
         <mxCell id="r7VOtmBWi9sTdI5Oyx6i-33" value="" style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;fillColor=none;dashed=1;labelBackgroundColor=none;" parent="1" vertex="1">
           <mxGeometry x="215.005" y="340" width="310" height="340" as="geometry" />
         </mxCell>
@@ -88,9 +82,6 @@
               <mxPoint x="245.005" y="490" />
             </Array>
           </mxGeometry>
-        </mxCell>
-        <mxCell id="r7VOtmBWi9sTdI5Oyx6i-46" value="&lt;i style=&quot;border-color: var(--border-color); color: rgb(0, 0, 0); font-family: Helvetica; font-size: 16px; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(251, 251, 251); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;&quot;&gt;Embedded proofs&lt;/i&gt;" style="text;whiteSpace=wrap;html=1;fontSize=16;align=center;rounded=1;labelBackgroundColor=none;" parent="1" vertex="1">
-          <mxGeometry x="266.505" y="650" width="220" height="40" as="geometry" />
         </mxCell>
         <mxCell id="Xbw9OttzSYU2m0TrLEde-5" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0.5;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;fontSize=12;startSize=8;endSize=8;startArrow=classic;startFill=1;endArrow=none;endFill=0;" parent="1" source="Xbw9OttzSYU2m0TrLEde-2" target="r7VOtmBWi9sTdI5Oyx6i-1" edge="1">
           <mxGeometry relative="1" as="geometry" />
@@ -156,6 +147,15 @@
             <mxPoint x="630" y="680" as="sourcePoint" />
             <mxPoint x="680" y="630" as="targetPoint" />
           </mxGeometry>
+        </mxCell>
+        <mxCell id="7Y__Ef_JBj4FKFU6f0si-1" value="&lt;i&gt;Enveloping Proofs&lt;/i&gt;" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=16;" vertex="1" parent="1">
+          <mxGeometry x="657.01" y="650" width="150" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7Y__Ef_JBj4FKFU6f0si-2" value="&lt;i&gt;Embedded proofs&lt;/i&gt;" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=16;" vertex="1" parent="1">
+          <mxGeometry x="301.51" y="650" width="150" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="7Y__Ef_JBj4FKFU6f0si-3" value="&lt;i&gt;Securing mechanisms of VCs&lt;/i&gt;" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=16;" vertex="1" parent="1">
+          <mxGeometry x="430" y="700" width="230" height="30" as="geometry" />
         </mxCell>
       </root>
     </mxGraphModel>

--- a/diagrams/VCWG_specifications.svg
+++ b/diagrams/VCWG_specifications.svg
@@ -1,338 +1,324 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="background:#fff" viewBox="-0.5 -0.5 1061 719">
-    <rect width="100%" height="100%" fill="#FFF" style="fill:light-dark(#fff,#121212)"/>
-    <rect width="720" height="410" x="129.76" y="276" fill="none" stroke="#000" stroke-dasharray="3 3" pointer-events="all" rx="61.5" ry="61.5" style="stroke:light-dark(#000,#fff)"/>
-    <g stroke="#000" stroke-miterlimit="10">
-        <path fill="none" d="M321.51 316V90q0-10 10-10h10.38" pointer-events="stroke" style="stroke:light-dark(#000,#fff)"/>
-        <path d="m348.64 80-9 4.5 2.25-4.5-2.25-4.5Z" pointer-events="all" style="fill:light-dark(#000,#fff);stroke:light-dark(#000,#fff)"/>
-    </g>
-    <g stroke="#000" stroke-miterlimit="10">
-        <path fill="none" d="M668.76 316V90q0-10-10-10h-21.14" pointer-events="stroke" style="stroke:light-dark(#000,#fff)"/>
-        <path d="m630.87 80 9-4.5-2.25 4.5 2.25 4.5Z" pointer-events="all" style="fill:light-dark(#000,#fff);stroke:light-dark(#000,#fff)"/>
-    </g>
-    <rect width="220" height="40" x="380.01" y="658" fill="none" pointer-events="all" rx="6" ry="6"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe flex-start;justify-content:unsafe center;width:218px;height:1px;padding-top:665px;margin-left:381px">
-                <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
-                    <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:light-dark(#000,#fff);line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
-                        <i style="border-color:var(--border-color);color:light-dark(#000,#000);font-family:Helvetica;font-size:16px;font-variant-ligatures:normal;font-variant-caps:normal;font-weight:400;letter-spacing:normal;orphans:2;text-indent:0;text-transform:none;widows:2;word-spacing:0;-webkit-text-stroke-width:0;background-color:light-dark(#fbfbfb,#fbfbfb);text-decoration-thickness:initial;text-decoration-style:initial;text-decoration-color:initial">
-                            Securing
-                                        mechanisms of VCs
-                        </i>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="490" y="681" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">Securing mechanisms of
-                        VCs</text>
-    </switch>
-    <rect width="310" height="340" x="510.01" y="296" fill="none" stroke="#000" stroke-dasharray="3 3" pointer-events="all" rx="46.5" ry="46.5" style="stroke:light-dark(#000,#fff)"/>
-    <a xlink:href="https://www.w3.org/TR/vc-jose-cose/" target="_blank">
-        <rect width="237.5" height="50" x="550.01" y="316" fill="none" stroke="#000" pointer-events="all" rx="7.5" ry="7.5" style="stroke:light-dark(#000,#fff)"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:236px;height:1px;padding-top:341px;margin-left:551px">
-                    <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
-                        <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:light-dark(#000,#fff);line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
-                            <font>
-                                <span style="font-size:20px">
-                                    JOSE and COSE
-                                    <br/>
-                                </span>
-                                <span style="font-size:10px">
-                                    <i>
-                                        Enveloping proofs using JWS, SD-JWT, or
-                                                    CBOR
-                                    </i>
-                                </span>
-                                <br/>
-                            </font>
-                        </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="669" y="346" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">JOSE and
-                            COSE...</text>
-        </switch>
-    </a>
-    <rect width="220" height="40" x="558.76" y="606" fill="none" pointer-events="all" rx="6" ry="6"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe flex-start;justify-content:unsafe center;width:218px;height:1px;padding-top:613px;margin-left:560px">
-                <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
-                    <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:light-dark(#000,#fff);line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
-                        <i style="border-color:var(--border-color);color:light-dark(#000,#000);font-family:Helvetica;font-size:16px;font-variant-ligatures:normal;font-variant-caps:normal;font-weight:400;letter-spacing:normal;orphans:2;text-indent:0;text-transform:none;widows:2;word-spacing:0;-webkit-text-stroke-width:0;background-color:light-dark(#fbfbfb,#fbfbfb);text-decoration-thickness:initial;text-decoration-style:initial;text-decoration-color:initial">
-                            Enveloping
-                                        proofs
-                        </i>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="669" y="629" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">Enveloping
-                        proofs</text>
-    </switch>
-    <rect width="310" height="340" x="160.01" y="296" fill="none" stroke="#000" stroke-dasharray="3 3" pointer-events="all" rx="46.5" ry="46.5" style="stroke:light-dark(#000,#fff)"/>
-    <a xlink:href="https://www.w3.org/TR/vc-di-eddsa/" target="_blank">
-        <rect width="215" height="50" x="240.01" y="393" fill="none" stroke="#000" pointer-events="all" rx="7.5" ry="7.5" style="stroke:light-dark(#000,#fff)"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:213px;height:1px;padding-top:418px;margin-left:241px">
-                    <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
-                        <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:light-dark(#000,#fff);line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
-                            <span style="font-size:20px">
-                                Ed
-                            </span>
-                            <span style="font-size:20px;background-color:initial">
-                                DSA Cryptosuites
-                            </span>
-                            <div>
-                                <font style="font-size:10px">
-                                    <i>
-                                        Data Integrity with Edwards elliptic
-                                                    curves
-                                    </i>
-                                </font>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="background:0 0;background-color:transparent;color-scheme:light" viewBox="-0.5 -0.5 1061 707">
+    <g data-cell-id="0">
+        <g data-cell-id="1">
+            <rect width="720" height="410" x="129.76" y="276" fill="none" stroke="#000" stroke-dasharray="3 3" data-cell-id="r7VOtmBWi9sTdI5Oyx6i-44" pointer-events="all" rx="61.5" ry="61.5" style="stroke:#000"/>
+            <g stroke="#000" stroke-miterlimit="10" data-cell-id="r7VOtmBWi9sTdI5Oyx6i-20">
+                <path fill="none" d="M321.51 316V90q0-10 10-10h10.38" pointer-events="stroke" style="stroke:#000"/>
+                <path d="m348.64 80-9 4.5 2.25-4.5-2.25-4.5Z" pointer-events="all" style="fill:#000;stroke:#000"/>
+            </g>
+            <g stroke="#000" stroke-miterlimit="10" data-cell-id="r7VOtmBWi9sTdI5Oyx6i-21">
+                <path fill="none" d="M668.76 316V90q0-10-10-10h-21.14" pointer-events="stroke" style="stroke:#000"/>
+                <path d="m630.87 80 9-4.5-2.25 4.5 2.25 4.5Z" pointer-events="all" style="fill:#000;stroke:#000"/>
+            </g>
+            <rect width="310" height="340" x="510.01" y="296" fill="none" stroke="#000" stroke-dasharray="3 3" data-cell-id="r7VOtmBWi9sTdI5Oyx6i-34" pointer-events="all" rx="46.5" ry="46.5" style="stroke:#000"/>
+            <a xlink:href="https://www.w3.org/TR/vc-jose-cose/" data-cell-id="r7VOtmBWi9sTdI5Oyx6i-6" target="_blank">
+                <rect width="237.5" height="50" x="550.01" y="316" fill="none" stroke="#000" pointer-events="all" rx="7.5" ry="7.5" style="stroke:#000"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:236px;height:1px;padding-top:341px;margin-left:551px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <font>
+                                        <span style="font-size:20px">
+                                            JOSE and COSE
+                                            <br/>
+                                        </span>
+                                        <span style="font-size:10px">
+                                            <i>
+                                                Enveloping proofs using JWS, SD-JWT, or CBOR
+                                            </i>
+                                        </span>
+                                        <br/>
+                                    </font>
+                                </div>
                             </div>
                         </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="348" y="423" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">EdDSA
-                            Cryptosuites...</text>
-        </switch>
-    </a>
-    <a xlink:href="https://www.w3.org/TR/vc-di-ecdsa/" target="_blank">
-        <rect width="215" height="50" x="240.01" y="466" fill="none" stroke="#000" pointer-events="all" rx="7.5" ry="7.5" style="stroke:light-dark(#000,#fff)"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:213px;height:1px;padding-top:491px;margin-left:241px">
-                    <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
-                        <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:light-dark(#000,#fff);line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
-                            <span style="font-size:20px">
-                                ECDSA Cryptosuites
-                            </span>
-                            <br/>
-                            <font style="font-size:10px">
-                                <i>
-                                    Data Integrity with NIST elliptic curves
-                                </i>
-                            </font>
-                        </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="348" y="496" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">ECDSA
-                            Cryptosuites...</text>
-        </switch>
-    </a>
-    <a xlink:href="https://www.w3.org/TR/vc-di-bbs/" target="_blank">
-        <rect width="215" height="50" x="240.01" y="539" fill="none" stroke="#000" pointer-events="all" rx="7.5" ry="7.5" style="stroke:light-dark(#000,#fff)"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:213px;height:1px;padding-top:564px;margin-left:241px">
-                    <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
-                        <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:light-dark(#000,#fff);line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
-                            <span style="font-size:20px">
-                                BBS Cryptosuites
-                            </span>
-                            <br/>
-                            <font style="font-size:10px">
-                                <i>
-                                    Data Integrity with BBS selective
-                                                disclosures
-                                </i>
-                            </font>
-                        </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="348" y="569" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">BBS
-                            Cryptosuites...</text>
-        </switch>
-    </a>
-    <a xlink:href="https://www.w3.org/TR/vc-data-integrity/" target="_blank">
-        <rect width="215" height="50" x="214.01" y="316" fill="none" stroke="#000" pointer-events="all" rx="7.5" ry="7.5" style="stroke:light-dark(#000,#fff)"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:213px;height:1px;padding-top:341px;margin-left:215px">
-                    <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
-                        <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:light-dark(#000,#fff);line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
-                            <font style="font-size:20px">
-                                Data Integrity
-                            </font>
-                            <br/>
-                            <font style="font-size:10px">
-                                <i>
-                                    General structure of embedded proofs
-                                </i>
-                            </font>
-                        </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="322" y="346" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">Data
-                            Integrity...</text>
-        </switch>
-    </a>
-    <g stroke="#000" stroke-miterlimit="10">
-        <path fill="none" d="M240.01 418h-40q-10 0-10-10v-57q0-10 8.06-10h8.07" pointer-events="stroke" style="stroke:light-dark(#000,#fff)"/>
-        <path d="m212.89 341-9 4.5 2.25-4.5-2.25-4.5Z" pointer-events="all" style="fill:light-dark(#000,#fff);stroke:light-dark(#000,#fff)"/>
-    </g>
-    <g stroke="#000" stroke-miterlimit="10">
-        <path fill="none" d="M240.01 491h-40q-10 0-10-10V351q0-10 8.06-10h8.07" pointer-events="stroke" style="stroke:light-dark(#000,#fff)"/>
-        <path d="m212.89 341-9 4.5 2.25-4.5-2.25-4.5Z" pointer-events="all" style="fill:light-dark(#000,#fff);stroke:light-dark(#000,#fff)"/>
-    </g>
-    <g stroke="#000" stroke-miterlimit="10">
-        <path fill="none" d="M240.01 564h-40q-10 0-10-10V351q0-10 8.06-10h8.07" pointer-events="stroke" style="stroke:light-dark(#000,#fff)"/>
-        <path d="m212.89 341-9 4.5 2.25-4.5-2.25-4.5Z" pointer-events="all" style="fill:light-dark(#000,#fff);stroke:light-dark(#000,#fff)"/>
-    </g>
-    <rect width="220" height="40" x="211.51" y="606" fill="none" pointer-events="all" rx="6" ry="6"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe flex-start;justify-content:unsafe center;width:218px;height:1px;padding-top:613px;margin-left:213px">
-                <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
-                    <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:light-dark(#000,#fff);line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
-                        <i style="border-color:var(--border-color);color:light-dark(#000,#000);font-family:Helvetica;font-size:16px;font-variant-ligatures:normal;font-variant-caps:normal;font-weight:400;letter-spacing:normal;orphans:2;text-indent:0;text-transform:none;widows:2;word-spacing:0;-webkit-text-stroke-width:0;background-color:light-dark(#fbfbfb,#fbfbfb);text-decoration-thickness:initial;text-decoration-style:initial;text-decoration-color:initial">
-                            Embedded
-                                        proofs
-                        </i>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="322" y="629" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">Embedded proofs</text>
-    </switch>
-    <g stroke="#000" stroke-miterlimit="10">
-        <path fill="none" d="m489.96 143.13-.2-43.13" pointer-events="stroke" style="stroke:light-dark(#000,#fff)"/>
-        <path d="m489.99 149.88-4.54-8.98 4.51 2.23 4.49-2.27Z" pointer-events="all" style="fill:light-dark(#000,#fff);stroke:light-dark(#000,#fff)"/>
-    </g>
-    <a xlink:href="https://www.w3.org/TR/cid-1.0/" target="_blank">
-        <rect width="290" height="70" x="345" y="151" fill="none" stroke="#000" pointer-events="all" rx="10.5" ry="10.5" style="stroke:light-dark(#000,#fff)"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:288px;height:1px;padding-top:186px;margin-left:346px">
-                    <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
-                        <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:light-dark(#000,#fff);line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
-                            <font>
-                                <span style="font-size:20px">
-                                    Controlled Identifiers
-                                </span>
-                            </font>
-                            <div>
-                                <font>
-                                    <i style="font-size:10px">
-                                        Common definitions for
-                                                    verification methods and relationships, and key
-                                                    representations
-                                    </i>
-                                    <br/>
-                                </font>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="669" y="346" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">JOSE and COSE...</text>
+                </switch>
+            </a>
+            <rect width="310" height="340" x="160.01" y="296" fill="none" stroke="#000" stroke-dasharray="3 3" data-cell-id="r7VOtmBWi9sTdI5Oyx6i-33" pointer-events="all" rx="46.5" ry="46.5" style="stroke:#000"/>
+            <a xlink:href="https://www.w3.org/TR/vc-di-eddsa/" data-cell-id="r7VOtmBWi9sTdI5Oyx6i-3" target="_blank">
+                <rect width="215" height="50" x="240.01" y="393" fill="none" stroke="#000" pointer-events="all" rx="7.5" ry="7.5" style="stroke:#000"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:213px;height:1px;padding-top:418px;margin-left:241px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <span style="font-size:20px">
+                                        Ed
+                                    </span>
+                                    <span style="font-size:20px;background-color:initial">
+                                        DSA Cryptosuites
+                                    </span>
+                                    <div>
+                                        <font style="font-size:10px">
+                                            <i>
+                                                Data Integrity with Edwards elliptic curves
+                                            </i>
+                                        </font>
+                                    </div>
+                                </div>
                             </div>
                         </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="490" y="191" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">Controlled
-                            Identifiers...</text>
-        </switch>
-    </a>
-    <a xlink:href="https://www.w3.org/TR/vc-data-model-2.0/" target="_blank">
-        <rect width="280" height="80" x="349.76" y="20" fill="none" stroke="#000" pointer-events="all" rx="12" ry="12" style="stroke:light-dark(#000,#fff)"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:278px;height:1px;padding-top:60px;margin-left:351px">
-                    <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
-                        <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:light-dark(#000,#fff);line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
-                            <font style="font-size:20px">
-                                VC Data Model
-                            </font>
-                            <br/>
-                            <font style="font-size:10px">
-                                <i>
-                                    Graph based model of verifiable claims in JSON
-                                                for Issuer-Holder-Verifier relationships
-                                </i>
-                            </font>
-                        </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="490" y="65" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">VC Data
-                            Model...</text>
-        </switch>
-    </a>
-    <a xlink:href="https://www.w3.org/TR/vc-json-schema/" target="_blank">
-        <rect width="240" height="60" x="20.01" y="98" fill="none" stroke="#000" pointer-events="all" rx="9" ry="9" style="stroke:light-dark(#000,#fff)"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:238px;height:1px;padding-top:128px;margin-left:21px">
-                    <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
-                        <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:light-dark(#000,#fff);line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
-                            <font>
-                                <span style="font-size:20px">
-                                    JSON Schema
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="348" y="423" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">EdDSA Cryptosuites...</text>
+                </switch>
+            </a>
+            <a xlink:href="https://www.w3.org/TR/vc-di-ecdsa/" data-cell-id="r7VOtmBWi9sTdI5Oyx6i-4" target="_blank">
+                <rect width="215" height="50" x="240.01" y="466" fill="none" stroke="#000" pointer-events="all" rx="7.5" ry="7.5" style="stroke:#000"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:213px;height:1px;padding-top:491px;margin-left:241px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <span style="font-size:20px">
+                                        ECDSA Cryptosuites
+                                    </span>
                                     <br/>
-                                </span>
-                                <i style="font-size:10px">
-                                    JSON Schemas for the structural checking of
-                                                VCs
-                                </i>
-                                <br/>
-                            </font>
+                                    <font style="font-size:10px">
+                                        <i>
+                                            Data Integrity with NIST elliptic curves
+                                        </i>
+                                    </font>
+                                </div>
+                            </div>
                         </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="140" y="133" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">JSON
-                            Schema...</text>
-        </switch>
-    </a>
-    <a xlink:href="https://www.w3.org/TR/vc-bitstring-status-list/" target="_blank">
-        <rect width="287.5" height="60" x="752.01" y="98" fill="none" stroke="#000" pointer-events="all" rx="9" ry="9" style="stroke:light-dark(#000,#fff)"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:286px;height:1px;padding-top:128px;margin-left:753px">
-                    <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
-                        <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:light-dark(#000,#fff);line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
-                            <font>
-                                <span style="font-size:20px">
-                                    Bitstring Status
-                                                List
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="348" y="496" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">ECDSA Cryptosuites...</text>
+                </switch>
+            </a>
+            <a xlink:href="https://www.w3.org/TR/vc-di-bbs/" data-cell-id="r7VOtmBWi9sTdI5Oyx6i-5" target="_blank">
+                <rect width="215" height="50" x="240.01" y="539" fill="none" stroke="#000" pointer-events="all" rx="7.5" ry="7.5" style="stroke:#000"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:213px;height:1px;padding-top:564px;margin-left:241px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <span style="font-size:20px">
+                                        BBS Cryptosuites
+                                    </span>
                                     <br/>
-                                </span>
-                                <i style="font-size:10px">
-                                    Publishing status
-                                                information for VCs using bitstrings
-                                </i>
-                                <br/>
-                            </font>
+                                    <font style="font-size:10px">
+                                        <i>
+                                            Data Integrity with BBS selective disclosures
+                                        </i>
+                                    </font>
+                                </div>
+                            </div>
                         </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="896" y="133" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">Bitstring Status
-                            List...</text>
-        </switch>
-    </a>
-    <g stroke="#000" stroke-miterlimit="10">
-        <path fill="none" d="M140.01 98V70q0-10 10-10h191.88" pointer-events="stroke" style="stroke:light-dark(#000,#fff)"/>
-        <path d="m348.64 60-9 4.5 2.25-4.5-2.25-4.5Z" pointer-events="all" style="fill:light-dark(#000,#fff);stroke:light-dark(#000,#fff)"/>
-    </g>
-    <g stroke="#000" stroke-miterlimit="10">
-        <path fill="none" d="m895.76 98 .18-28q.07-10-9.93-10H637.62" pointer-events="stroke" style="stroke:light-dark(#000,#fff)"/>
-        <path d="m630.87 60 9-4.5-2.25 4.5 2.25 4.5Z" pointer-events="all" style="fill:light-dark(#000,#fff);stroke:light-dark(#000,#fff)"/>
-    </g>
-    <g stroke="#000" stroke-miterlimit="10">
-        <path fill="none" d="M609.38 316v-50q0-10-10-10H572.5q-10 0-10-10v-17.13" pointer-events="stroke" style="stroke:light-dark(#000,#fff)"/>
-        <path d="m562.5 222.12 4.5 9-4.5-2.25-4.5 2.25Z" pointer-events="all" style="fill:light-dark(#000,#fff);stroke:light-dark(#000,#fff)"/>
-    </g>
-    <g stroke="#000" stroke-miterlimit="10">
-        <path fill="none" d="M375.26 316v-50q0-10 10-10h22.24q10 0 10-10v-17.13" pointer-events="stroke" style="stroke:light-dark(#000,#fff)"/>
-        <path d="m417.5 222.12 4.5 9-4.5-2.25-4.5 2.25Z" pointer-events="all" style="fill:light-dark(#000,#fff);stroke:light-dark(#000,#fff)"/>
-    </g>
-    <g stroke="#000" stroke-miterlimit="10">
-        <path fill="none" d="M347.51 539v-15.13" pointer-events="stroke" style="stroke:light-dark(#000,#fff)"/>
-        <path d="m347.51 517.12 4.5 9-4.5-2.25-4.5 2.25Z" pointer-events="all" style="fill:light-dark(#000,#fff);stroke:light-dark(#000,#fff)"/>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="348" y="569" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">BBS Cryptosuites...</text>
+                </switch>
+            </a>
+            <a xlink:href="https://www.w3.org/TR/vc-data-integrity/" data-cell-id="r7VOtmBWi9sTdI5Oyx6i-2" target="_blank">
+                <rect width="215" height="50" x="214.01" y="316" fill="none" stroke="#000" pointer-events="all" rx="7.5" ry="7.5" style="stroke:#000"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:213px;height:1px;padding-top:341px;margin-left:215px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <font style="font-size:20px">
+                                        Data Integrity
+                                    </font>
+                                    <br/>
+                                    <font style="font-size:10px">
+                                        <i>
+                                            General structure of embedded proofs
+                                        </i>
+                                    </font>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="322" y="346" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">Data Integrity...</text>
+                </switch>
+            </a>
+            <g stroke="#000" stroke-miterlimit="10" data-cell-id="r7VOtmBWi9sTdI5Oyx6i-37">
+                <path fill="none" d="M240.01 418h-40q-10 0-10-10v-57q0-10 8.06-10h8.07" pointer-events="stroke" style="stroke:#000"/>
+                <path d="m212.89 341-9 4.5 2.25-4.5-2.25-4.5Z" pointer-events="all" style="fill:#000;stroke:#000"/>
+            </g>
+            <g stroke="#000" stroke-miterlimit="10" data-cell-id="r7VOtmBWi9sTdI5Oyx6i-38">
+                <path fill="none" d="M240.01 491h-40q-10 0-10-10V351q0-10 8.06-10h8.07" pointer-events="stroke" style="stroke:#000"/>
+                <path d="m212.89 341-9 4.5 2.25-4.5-2.25-4.5Z" pointer-events="all" style="fill:#000;stroke:#000"/>
+            </g>
+            <g stroke="#000" stroke-miterlimit="10" data-cell-id="r7VOtmBWi9sTdI5Oyx6i-39">
+                <path fill="none" d="M240.01 564h-40q-10 0-10-10V351q0-10 8.06-10h8.07" pointer-events="stroke" style="stroke:#000"/>
+                <path d="m212.89 341-9 4.5 2.25-4.5-2.25-4.5Z" pointer-events="all" style="fill:#000;stroke:#000"/>
+            </g>
+            <g stroke="#000" stroke-miterlimit="10" data-cell-id="Xbw9OttzSYU2m0TrLEde-5">
+                <path fill="none" d="m489.96 143.13-.2-43.13" pointer-events="stroke" style="stroke:#000"/>
+                <path d="m489.99 149.88-4.54-8.98 4.51 2.23 4.49-2.27Z" pointer-events="all" style="fill:#000;stroke:#000"/>
+            </g>
+            <a xlink:href="https://www.w3.org/TR/cid-1.0/" data-cell-id="Xbw9OttzSYU2m0TrLEde-2" target="_blank">
+                <rect width="290" height="70" x="345" y="151" fill="none" stroke="#000" pointer-events="all" rx="10.5" ry="10.5" style="stroke:#000"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:288px;height:1px;padding-top:186px;margin-left:346px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <font>
+                                        <span style="font-size:20px">
+                                            Controlled Identifiers
+                                        </span>
+                                    </font>
+                                    <div>
+                                        <font>
+                                            <i style="font-size:10px">
+                                                Common definitions for verification methods and relationships, and key representations
+                                            </i>
+                                            <br/>
+                                        </font>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="490" y="191" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">Controlled Identifiers...</text>
+                </switch>
+            </a>
+            <a xlink:href="https://www.w3.org/TR/vc-data-model-2.0/" data-cell-id="r7VOtmBWi9sTdI5Oyx6i-1" target="_blank">
+                <rect width="280" height="80" x="349.76" y="20" fill="none" stroke="#000" pointer-events="all" rx="12" ry="12" style="stroke:#000"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:278px;height:1px;padding-top:60px;margin-left:351px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <font style="font-size:20px">
+                                        VC Data Model
+                                    </font>
+                                    <br/>
+                                    <font style="font-size:10px">
+                                        <i>
+                                            Graph based model of verifiable claims in JSON for Issuer-Holder-Verifier relationships
+                                        </i>
+                                    </font>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="490" y="65" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">VC Data Model...</text>
+                </switch>
+            </a>
+            <a xlink:href="https://www.w3.org/TR/vc-json-schema/" data-cell-id="r7VOtmBWi9sTdI5Oyx6i-7" target="_blank">
+                <rect width="240" height="60" x="20.01" y="98" fill="none" stroke="#000" pointer-events="all" rx="9" ry="9" style="stroke:#000"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:238px;height:1px;padding-top:128px;margin-left:21px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <font>
+                                        <span style="font-size:20px">
+                                            JSON Schema
+                                            <br/>
+                                        </span>
+                                        <i style="font-size:10px">
+                                            JSON Schemas for the structural checking of VCs
+                                        </i>
+                                        <br/>
+                                    </font>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="140" y="133" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">JSON Schema...</text>
+                </switch>
+            </a>
+            <a xlink:href="https://www.w3.org/TR/vc-bitstring-status-list/" data-cell-id="r7VOtmBWi9sTdI5Oyx6i-8" target="_blank">
+                <rect width="287.5" height="60" x="752.01" y="98" fill="none" stroke="#000" pointer-events="all" rx="9" ry="9" style="stroke:#000"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:286px;height:1px;padding-top:128px;margin-left:753px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <font>
+                                        <span style="font-size:20px">
+                                            Bitstring Status List
+                                            <br/>
+                                        </span>
+                                        <i style="font-size:10px">
+                                            Publishing status information for VCs using bitstrings
+                                        </i>
+                                        <br/>
+                                    </font>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="896" y="133" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">Bitstring Status List...</text>
+                </switch>
+            </a>
+            <g stroke="#000" stroke-miterlimit="10" data-cell-id="r7VOtmBWi9sTdI5Oyx6i-23">
+                <path fill="none" d="M140.01 98V70q0-10 10-10h191.88" pointer-events="stroke" style="stroke:#000"/>
+                <path d="m348.64 60-9 4.5 2.25-4.5-2.25-4.5Z" pointer-events="all" style="fill:#000;stroke:#000"/>
+            </g>
+            <g stroke="#000" stroke-miterlimit="10" data-cell-id="r7VOtmBWi9sTdI5Oyx6i-24">
+                <path fill="none" d="m895.76 98 .18-28q.07-10-9.93-10H637.62" pointer-events="stroke" style="stroke:#000"/>
+                <path d="m630.87 60 9-4.5-2.25 4.5 2.25 4.5Z" pointer-events="all" style="fill:#000;stroke:#000"/>
+            </g>
+            <g stroke="#000" stroke-miterlimit="10" data-cell-id="Xbw9OttzSYU2m0TrLEde-3">
+                <path fill="none" d="M609.38 316v-50q0-10-10-10H572.5q-10 0-10-10v-17.13" pointer-events="stroke" style="stroke:#000"/>
+                <path d="m562.5 222.12 4.5 9-4.5-2.25-4.5 2.25Z" pointer-events="all" style="fill:#000;stroke:#000"/>
+            </g>
+            <g stroke="#000" stroke-miterlimit="10" data-cell-id="Xbw9OttzSYU2m0TrLEde-4">
+                <path fill="none" d="M375.26 316v-50q0-10 10-10h22.24q10 0 10-10v-17.13" pointer-events="stroke" style="stroke:#000"/>
+                <path d="m417.5 222.12 4.5 9-4.5-2.25-4.5 2.25Z" pointer-events="all" style="fill:#000;stroke:#000"/>
+            </g>
+            <g stroke="#000" stroke-miterlimit="10" data-cell-id="o33hrdEk1rEdeaYNmZue-1">
+                <path fill="none" d="M347.51 539v-15.13" pointer-events="stroke" style="stroke:#000"/>
+                <path d="m347.51 517.12 4.5 9-4.5-2.25-4.5 2.25Z" pointer-events="all" style="fill:#000;stroke:#000"/>
+            </g>
+            <g data-cell-id="7Y__Ef_JBj4FKFU6f0si-1">
+                <rect width="150" height="30" x="602.01" y="606" fill="none" pointer-events="all"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:621px;margin-left:677px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
+                                    <i>
+                                        Enveloping Proofs
+                                    </i>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="677" y="626" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">Enveloping Proofs</text>
+                </switch>
+            </g>
+            <g data-cell-id="7Y__Ef_JBj4FKFU6f0si-2">
+                <rect width="150" height="30" x="246.51" y="606" fill="none" pointer-events="all"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:621px;margin-left:322px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
+                                    <i>
+                                        Embedded proofs
+                                    </i>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="322" y="626" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">Embedded proofs</text>
+                </switch>
+            </g>
+            <g data-cell-id="7Y__Ef_JBj4FKFU6f0si-3">
+                <rect width="230" height="30" x="375" y="656" fill="none" pointer-events="all"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:671px;margin-left:490px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
+                                    <i>
+                                        Securing mechanisms of VCs
+                                    </i>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="490" y="676" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">Securing mechanisms of VCs</text>
+                </switch>
+            </g>
+        </g>
     </g>
 </svg>

--- a/diagrams/claim.drawio
+++ b/diagrams/claim.drawio
@@ -1,6 +1,6 @@
-<mxfile host="Electron" modified="2024-03-12T16:02:46.288Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/24.0.4 Chrome/120.0.6099.109 Electron/28.1.0 Safari/537.36" etag="UftCXAJBqIPXLlsHPOsS" version="24.0.4" type="device">
+<mxfile host="Electron" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/26.2.15 Chrome/134.0.6998.205 Electron/35.2.1 Safari/537.36" version="26.2.15">
   <diagram name="Page-1" id="ZRe_wIOORr0k_d4isBBX">
-    <mxGraphModel dx="2219" dy="1840" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
+    <mxGraphModel dx="2002" dy="1748" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
@@ -20,9 +20,9 @@
             <mxPoint x="-681.5" y="-85.61" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="I-3xDNqU13IutiKupr62-28" value="&amp;nbsp;Property&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="I-3xDNqU13IutiKupr62-27" vertex="1" connectable="0">
+        <mxCell id="I-3xDNqU13IutiKupr62-28" value="&amp;nbsp;Property&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;labelBackgroundColor=none;" parent="I-3xDNqU13IutiKupr62-27" vertex="1" connectable="0">
           <mxGeometry x="0.1345" y="-2" relative="1" as="geometry">
-            <mxPoint x="-10" y="-5" as="offset" />
+            <mxPoint x="-10" y="-14" as="offset" />
           </mxGeometry>
         </mxCell>
       </root>

--- a/diagrams/claim.svg
+++ b/diagrams/claim.svg
@@ -1,52 +1,62 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-0.5 -0.5 602 82">
-    <ellipse cx="94.5" cy="41" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="73.5" ry="19.61"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:145px;height:1px;padding-top:41px;margin-left:22px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <i>
-                            <font color="#000">
-                                Subject
-                            </font>
-                        </i>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="95" y="46" font-family="Helvetica" font-size="16" text-anchor="middle">Subject</text>
-    </switch>
-    <rect width="140" height="40" x="441" y="21" fill="none" stroke="#000" stroke-width="2" pointer-events="all"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:138px;height:1px;padding-top:41px;margin-left:442px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <i>
-                            <font color="#000">
-                                Value
-                            </font>
-                        </i>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="511" y="46" font-family="Helvetica" font-size="16" text-anchor="middle">Value</text>
-    </switch>
-    <g stroke="#000" stroke-miterlimit="10" stroke-width="2">
-        <path fill="none" d="M168 41h263.26" pointer-events="stroke"/>
-        <path d="m438.76 41-10 5 2.5-5-2.5-5Z" pointer-events="all"/>
+<svg xmlns="http://www.w3.org/2000/svg" style="background:0 0;background-color:transparent;color-scheme:light" viewBox="-0.5 -0.5 602 82">
+    <g data-cell-id="0">
+        <g data-cell-id="1">
+            <g data-cell-id="I-3xDNqU13IutiKupr62-4">
+                <ellipse cx="94.5" cy="41" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="73.5" ry="19.61" style="stroke:#360"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:145px;height:1px;padding-top:41px;margin-left:22px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <i>
+                                        <font color="#000" style="color:#000">
+                                            Subject
+                                        </font>
+                                    </i>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="95" y="46" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">Subject</text>
+                </switch>
+            </g>
+            <g data-cell-id="I-3xDNqU13IutiKupr62-12">
+                <rect width="140" height="40" x="441" y="21" fill="none" stroke="#000" stroke-width="2" pointer-events="all" style="stroke:#000"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:138px;height:1px;padding-top:41px;margin-left:442px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <i>
+                                        <font color="#000" style="color:#000">
+                                            Value
+                                        </font>
+                                    </i>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="511" y="46" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">Value</text>
+                </switch>
+            </g>
+            <g data-cell-id="I-3xDNqU13IutiKupr62-27">
+                <g stroke="#000" stroke-miterlimit="10" stroke-width="2">
+                    <path fill="none" d="M168 41h263.26" pointer-events="stroke" style="stroke:#000"/>
+                    <path d="m438.76 41-10 5 2.5-5-2.5-5Z" pointer-events="all" style="fill:#000;stroke:#000"/>
+                </g>
+                <switch data-cell-id="I-3xDNqU13IutiKupr62-28" transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:30px;margin-left:314px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
+                                    Property
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="314" y="34" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle"> Property </text>
+                </switch>
+            </g>
+        </g>
     </g>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:39px;margin-left:314px">
-                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
-                        Property
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="314" y="43" font-family="Helvetica" font-size="16" text-anchor="middle"> Property </text>
-    </switch>
 </svg>

--- a/diagrams/credential_example.drawio
+++ b/diagrams/credential_example.drawio
@@ -1,6 +1,6 @@
-<mxfile host="Electron" modified="2024-04-29T07:18:43.026Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/24.2.5 Chrome/120.0.6099.109 Electron/28.1.0 Safari/537.36" etag="nfqMuFwwQGArWCrEuA9O" version="24.2.5" type="device">
+<mxfile host="Electron" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/26.2.15 Chrome/134.0.6998.205 Electron/35.2.1 Safari/537.36" version="26.2.15">
   <diagram name="Page-1" id="ZRe_wIOORr0k_d4isBBX">
-    <mxGraphModel dx="3970" dy="2060" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
+    <mxGraphModel dx="3685" dy="1730" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
@@ -20,9 +20,9 @@
             <mxPoint x="-1797" y="-175" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="HRplg5cOvGm0gZk61Yn5-11" value="validFrom" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="HRplg5cOvGm0gZk61Yn5-10" vertex="1" connectable="0">
+        <mxCell id="HRplg5cOvGm0gZk61Yn5-11" value="validFrom" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;labelBackgroundColor=none;" parent="HRplg5cOvGm0gZk61Yn5-10" vertex="1" connectable="0">
           <mxGeometry x="0.1345" y="-2" relative="1" as="geometry">
-            <mxPoint x="-8" y="-5" as="offset" />
+            <mxPoint x="39" y="-9" as="offset" />
           </mxGeometry>
         </mxCell>
         <UserObject label="&lt;div&gt;&lt;i style=&quot;background-color: initial;&quot;&gt;https://www.example.org/persons/pat&lt;/i&gt;&lt;/div&gt;" id="HRplg5cOvGm0gZk61Yn5-12">
@@ -36,9 +36,9 @@
             <mxPoint x="-1890" y="-310" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="HRplg5cOvGm0gZk61Yn5-14" value="credentialSubject" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="HRplg5cOvGm0gZk61Yn5-13" vertex="1" connectable="0">
+        <mxCell id="HRplg5cOvGm0gZk61Yn5-14" value="credentialSubject" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;labelBackgroundColor=none;" parent="HRplg5cOvGm0gZk61Yn5-13" vertex="1" connectable="0">
           <mxGeometry x="0.1345" y="-2" relative="1" as="geometry">
-            <mxPoint x="-6" y="-5" as="offset" />
+            <mxPoint x="69" y="-5" as="offset" />
           </mxGeometry>
         </mxCell>
         <mxCell id="HRplg5cOvGm0gZk61Yn5-16" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=1;exitY=1;exitDx=0;exitDy=0;strokeWidth=2;fontStyle=2;" parent="1" source="HRplg5cOvGm0gZk61Yn5-12" target="HRplg5cOvGm0gZk61Yn5-15" edge="1">
@@ -47,9 +47,9 @@
             <mxPoint x="-1417" y="-310" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="HRplg5cOvGm0gZk61Yn5-17" value="name" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="HRplg5cOvGm0gZk61Yn5-16" vertex="1" connectable="0">
+        <mxCell id="HRplg5cOvGm0gZk61Yn5-17" value="name" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;labelBackgroundColor=none;" parent="HRplg5cOvGm0gZk61Yn5-16" vertex="1" connectable="0">
           <mxGeometry x="0.1345" y="-2" relative="1" as="geometry">
-            <mxPoint x="-2" y="-5" as="offset" />
+            <mxPoint x="28" y="-5" as="offset" />
           </mxGeometry>
         </mxCell>
         <mxCell id="HRplg5cOvGm0gZk61Yn5-20" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=0.5;entryY=0;entryDx=0;entryDy=0;exitX=0;exitY=1;exitDx=0;exitDy=0;strokeWidth=2;fontStyle=2" parent="1" source="HRplg5cOvGm0gZk61Yn5-12" target="E5f-8hAcM4Bx_eA0MOKK-1" edge="1">
@@ -58,9 +58,9 @@
             <mxPoint x="-1563" y="-340" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="HRplg5cOvGm0gZk61Yn5-21" value="alumniOf" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="HRplg5cOvGm0gZk61Yn5-20" vertex="1" connectable="0">
+        <mxCell id="HRplg5cOvGm0gZk61Yn5-21" value="alumniOf" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;labelBackgroundColor=none;" parent="HRplg5cOvGm0gZk61Yn5-20" vertex="1" connectable="0">
           <mxGeometry x="0.1345" y="-2" relative="1" as="geometry">
-            <mxPoint x="1" y="-5" as="offset" />
+            <mxPoint x="36" y="5" as="offset" />
           </mxGeometry>
         </mxCell>
         <UserObject label="&lt;i&gt;Pat&lt;/i&gt;" id="HRplg5cOvGm0gZk61Yn5-15">
@@ -84,9 +84,9 @@
             <mxPoint x="-1870" y="-140" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="E5f-8hAcM4Bx_eA0MOKK-3" value="name" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;" parent="E5f-8hAcM4Bx_eA0MOKK-2" vertex="1" connectable="0">
+        <mxCell id="E5f-8hAcM4Bx_eA0MOKK-3" value="name" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;labelBackgroundColor=none;" parent="E5f-8hAcM4Bx_eA0MOKK-2" vertex="1" connectable="0">
           <mxGeometry x="0.1345" y="-2" relative="1" as="geometry">
-            <mxPoint y="-5" as="offset" />
+            <mxPoint x="27" y="-8" as="offset" />
           </mxGeometry>
         </mxCell>
       </root>

--- a/diagrams/credential_example.svg
+++ b/diagrams/credential_example.svg
@@ -1,190 +1,216 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-0.5 -0.5 972 649">
-    <ellipse cx="419.5" cy="56" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="240" ry="35"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:478px;height:1px;padding-top:56px;margin-left:181px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <div>
-                            <i>
-                                https://university.example/Credential123
-                            </i>
+<svg xmlns="http://www.w3.org/2000/svg" style="background:0 0;background-color:transparent;color-scheme:light" viewBox="-0.5 -0.5 972 649">
+    <g data-cell-id="0">
+        <g data-cell-id="1">
+            <g data-cell-id="I-3xDNqU13IutiKupr62-4">
+                <ellipse cx="419.5" cy="56" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="240" ry="35" style="stroke:#360"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:478px;height:1px;padding-top:56px;margin-left:181px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <div>
+                                        <i>
+                                            https://university.example/Credential123
+                                        </i>
+                                    </div>
+                                    <div>
+                                        <i>
+                                            (Type: VerifiableCredential, ExampleAlumniCredential)
+                                        </i>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
-                        <div>
-                            <i>
-                                (Type: VerifiableCredential, ExampleAlumniCredential)
-                            </i>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="420" y="61" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">https://university.example/Credential123...</text>
+                </switch>
+            </g>
+            <g data-cell-id="HRplg5cOvGm0gZk61Yn5-5">
+                <rect width="240" height="40" x="711" y="265.81" fill="none" stroke="#000" stroke-width="2" pointer-events="all" style="stroke:#000"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:238px;height:1px;padding-top:286px;margin-left:712px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <div>
+                                        <i>
+                                            2010-01-01T00:00:00Z
+                                        </i>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="420" y="61" font-family="Helvetica" font-size="16" text-anchor="middle">http://university.example/Credential123...</text>
-    </switch>
-    <rect width="240" height="40" x="711" y="265.81" fill="none" stroke="#000" stroke-width="2" pointer-events="all"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:238px;height:1px;padding-top:286px;margin-left:712px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <div>
-                            <i>
-                                2010-01-01T00:00:00Z
-                            </i>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="831" y="291" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">2010-01-01T00:00:00Z</text>
+                </switch>
+            </g>
+            <g data-cell-id="HRplg5cOvGm0gZk61Yn5-10">
+                <g stroke="#000" stroke-miterlimit="10" stroke-width="2">
+                    <path fill="none" d="m589.21 80.75 234.06 179.14" pointer-events="stroke" style="stroke:#000"/>
+                    <path d="m829.22 264.45-10.98-2.11 5.03-2.45 1.05-5.49Z" pointer-events="all" style="fill:#000;stroke:#000"/>
+                </g>
+                <switch data-cell-id="HRplg5cOvGm0gZk61Yn5-11" transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:179px;margin-left:765px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
+                                    validFrom
+                                </div>
+                            </div>
                         </div>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="831" y="291" font-family="Helvetica" font-size="16" text-anchor="middle">2010-01-01T00:00:00Z</text>
-    </switch>
-    <g stroke="#000" stroke-miterlimit="10" stroke-width="2">
-        <path fill="none" d="m589.21 80.75 234.06 179.14" pointer-events="stroke"/>
-        <path d="m829.22 264.45-10.98-2.11 5.03-2.45 1.05-5.49Z" pointer-events="all"/>
-    </g>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:183px;margin-left:718px">
-                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
-                        validFrom
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="718" y="188" font-family="Helvetica" font-size="16" text-anchor="middle">validFrom</text>
-    </switch>
-    <ellipse cx="419.5" cy="285.81" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="168.5" ry="29.15"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:335px;height:1px;padding-top:286px;margin-left:252px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <div>
-                            <i style="background-color:initial">
-                                https://www.example.org/persons/pat
-                            </i>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="765" y="184" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">validFrom</text>
+                </switch>
+            </g>
+            <g data-cell-id="HRplg5cOvGm0gZk61Yn5-12">
+                <ellipse cx="419.5" cy="285.81" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="168.5" ry="29.15" style="stroke:#360"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:335px;height:1px;padding-top:286px;margin-left:252px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <div>
+                                        <i style="background-color:initial">
+                                            https://www.example.org/persons/pat
+                                        </i>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="420" y="291" font-family="Helvetica" font-size="16" text-anchor="middle">https://www.example.org/persons/pat</text>
-    </switch>
-    <g stroke="#000" stroke-miterlimit="10" stroke-width="2">
-        <path fill="none" d="M419.5 91v155.92" pointer-events="stroke"/>
-        <path d="m419.5 254.42-5-10 5 2.5 5-2.5Z" pointer-events="all"/>
-    </g>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:181px;margin-left:412px">
-                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
-                        credentialSubject
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="412" y="185" font-family="Helvetica" font-size="16" text-anchor="middle">credentialSubject</text>
-    </switch>
-    <g stroke="#000" stroke-miterlimit="10" stroke-width="2">
-        <path fill="none" d="m538.78 306.4 73.19 121.26" pointer-events="stroke"/>
-        <path d="m615.84 434.09-9.44-5.98 5.57-.45 2.99-4.72Z" pointer-events="all"/>
-    </g>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:377px;margin-left:580px">
-                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
-                        name
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="580" y="381" font-family="Helvetica" font-size="16" text-anchor="middle">name</text>
-    </switch>
-    <g stroke="#000" stroke-miterlimit="10" stroke-width="2">
-        <path fill="none" d="M300.22 306.4 196.26 414" pointer-events="stroke"/>
-        <path d="m191.05 419.39 3.36-10.66 1.85 5.27 5.34 1.67Z" pointer-events="all"/>
-    </g>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:365px;margin-left:238px">
-                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
-                        alumniOf
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="238" y="370" font-family="Helvetica" font-size="16" text-anchor="middle">alumniOf</text>
-    </switch>
-    <rect width="160" height="30" x="537" y="436" fill="none" stroke="#000" stroke-width="2" pointer-events="all"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:158px;height:1px;padding-top:451px;margin-left:538px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <i>
-                            Pat
-                        </i>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="617" y="456" font-family="Helvetica" font-size="16" text-anchor="middle">Pat</text>
-    </switch>
-    <rect width="240" height="37" x="69.5" y="591" fill="none" stroke="#000" stroke-width="2" pointer-events="all"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:238px;height:1px;padding-top:610px;margin-left:71px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <i>
-                            Example University
-                        </i>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="190" y="614" font-family="Helvetica" font-size="16" text-anchor="middle">Example University</text>
-    </switch>
-    <ellipse cx="189.5" cy="451" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="168.5" ry="30"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:335px;height:1px;padding-top:451px;margin-left:22px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <div>
-                            <i style="background-color:initial">
-                                did:example:
-                            </i>
-                            <span style="background-color:initial">
-                                <i>
-                                    c276e12ec21ebfeb1f712ebc6f1
-                                </i>
-                            </span>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="420" y="291" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">https://www.example.org/persons/pat</text>
+                </switch>
+            </g>
+            <g data-cell-id="HRplg5cOvGm0gZk61Yn5-13">
+                <g stroke="#000" stroke-miterlimit="10" stroke-width="2">
+                    <path fill="none" d="M419.5 91v155.92" pointer-events="stroke" style="stroke:#000"/>
+                    <path d="m419.5 254.42-5-10 5 2.5 5-2.5Z" pointer-events="all" style="fill:#000;stroke:#000"/>
+                </g>
+                <switch data-cell-id="HRplg5cOvGm0gZk61Yn5-14" transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:181px;margin-left:487px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
+                                    credentialSubject
+                                </div>
+                            </div>
                         </div>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="190" y="456" font-family="Helvetica" font-size="16" text-anchor="middle">did:example:c276e12ec21ebfeb1f712ebc6f1</text>
-    </switch>
-    <g stroke="#000" stroke-miterlimit="10" stroke-width="2">
-        <path fill="none" d="M189.5 481v100.26" pointer-events="stroke"/>
-        <path d="m189.5 588.76-5-10 5 2.5 5-2.5Z" pointer-events="all"/>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="487" y="185" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">credentialSubject</text>
+                </switch>
+            </g>
+            <g data-cell-id="HRplg5cOvGm0gZk61Yn5-16">
+                <g stroke="#000" stroke-miterlimit="10" stroke-width="2">
+                    <path fill="none" d="m538.78 306.4 73.19 121.26" pointer-events="stroke" style="stroke:#000"/>
+                    <path d="m615.84 434.09-9.44-5.98 5.57-.45 2.99-4.72Z" pointer-events="all" style="fill:#000;stroke:#000"/>
+                </g>
+                <switch data-cell-id="HRplg5cOvGm0gZk61Yn5-17" transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:377px;margin-left:610px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
+                                    name
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="610" y="381" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">name</text>
+                </switch>
+            </g>
+            <g data-cell-id="HRplg5cOvGm0gZk61Yn5-20">
+                <g stroke="#000" stroke-miterlimit="10" stroke-width="2">
+                    <path fill="none" d="M300.22 306.4 196.26 414" pointer-events="stroke" style="stroke:#000"/>
+                    <path d="m191.05 419.39 3.36-10.66 1.85 5.27 5.34 1.67Z" pointer-events="all" style="fill:#000;stroke:#000"/>
+                </g>
+                <switch data-cell-id="HRplg5cOvGm0gZk61Yn5-21" transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:375px;margin-left:273px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
+                                    alumniOf
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="273" y="380" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">alumniOf</text>
+                </switch>
+            </g>
+            <g data-cell-id="HRplg5cOvGm0gZk61Yn5-15">
+                <rect width="160" height="30" x="537" y="436" fill="none" stroke="#000" stroke-width="2" pointer-events="all" style="stroke:#000"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:158px;height:1px;padding-top:451px;margin-left:538px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <i>
+                                        Pat
+                                    </i>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="617" y="456" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">Pat</text>
+                </switch>
+            </g>
+            <g data-cell-id="HRplg5cOvGm0gZk61Yn5-19">
+                <rect width="240" height="37" x="69.5" y="591" fill="none" stroke="#000" stroke-width="2" pointer-events="all" style="stroke:#000"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:238px;height:1px;padding-top:610px;margin-left:71px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <i>
+                                        Example University
+                                    </i>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="190" y="614" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">Example University</text>
+                </switch>
+            </g>
+            <g data-cell-id="E5f-8hAcM4Bx_eA0MOKK-1">
+                <ellipse cx="189.5" cy="451" fill="none" stroke="#360" stroke-width="2" pointer-events="all" rx="168.5" ry="30" style="stroke:#360"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:335px;height:1px;padding-top:451px;margin-left:22px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <div>
+                                        <i style="background-color:initial">
+                                            did:example:
+                                        </i>
+                                        <span style="background-color:initial">
+                                            <i>
+                                                c276e12ec21ebfeb1f712ebc6f1
+                                            </i>
+                                        </span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="190" y="456" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">did:example:c276e12ec21ebfeb1f712ebc6f1</text>
+                </switch>
+            </g>
+            <g data-cell-id="E5f-8hAcM4Bx_eA0MOKK-2">
+                <g stroke="#000" stroke-miterlimit="10" stroke-width="2">
+                    <path fill="none" d="M189.5 481v100.26" pointer-events="stroke" style="stroke:#000"/>
+                    <path d="m189.5 588.76-5-10 5 2.5 5-2.5Z" pointer-events="all" style="fill:#000;stroke:#000"/>
+                </g>
+                <switch data-cell-id="E5f-8hAcM4Bx_eA0MOKK-3" transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:536px;margin-left:215px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
+                                    name
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="215" y="540" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">name</text>
+                </switch>
+            </g>
+        </g>
     </g>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:539px;margin-left:188px">
-                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
-                        name
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="188" y="543" font-family="Helvetica" font-size="16" text-anchor="middle">name</text>
-    </switch>
 </svg>

--- a/diagrams/cryptosuites.drawio
+++ b/diagrams/cryptosuites.drawio
@@ -1,6 +1,6 @@
-<mxfile host="Electron" modified="2024-05-20T14:29:31.771Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/24.4.0 Chrome/120.0.6099.109 Electron/28.1.0 Safari/537.36" etag="tVDcjrAf61mKmHhVAstv" version="24.4.0" type="device">
+<mxfile host="Electron" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/26.2.15 Chrome/134.0.6998.205 Electron/35.2.1 Safari/537.36" version="26.2.15">
   <diagram name="Page-1" id="6gULVhWcurzz5zKnDaAR">
-    <mxGraphModel dx="1600" dy="1216" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
+    <mxGraphModel dx="833" dy="921" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
@@ -144,8 +144,8 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="_o5h41joDnnrQmcQaRRM-25" value="&lt;i style=&quot;border-color: var(--border-color); color: rgb(0, 0, 0); font-family: Helvetica; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(251, 251, 251); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;&quot;&gt;&lt;font style=&quot;font-size: 15px;&quot;&gt;Selective disclosure schemes&lt;/font&gt;&lt;/i&gt;" style="text;whiteSpace=wrap;html=1;fontSize=16;align=center;rounded=1;labelBackgroundColor=none;" parent="1" vertex="1">
-          <mxGeometry x="565.005" y="780" width="220" height="40" as="geometry" />
+        <mxCell id="XB48tUagIdPG_h6vu15s-1" value="&lt;i&gt;Selective disclosure schemes&lt;/i&gt;" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=15;" vertex="1" parent="1">
+          <mxGeometry x="562.49" y="780" width="220" height="30" as="geometry" />
         </mxCell>
       </root>
     </mxGraphModel>

--- a/diagrams/cryptosuites.svg
+++ b/diagrams/cryptosuites.svg
@@ -1,280 +1,302 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="-0.5 -0.5 799 711">
-    <rect width="229.99" height="250" x="547.5" y="430" fill="none" stroke="#000" stroke-dasharray="3 3" pointer-events="all" rx="34.5" ry="34.5"/>
-    <a xlink:href="https://www.w3.org/TR/vc-json-schema/" target="_blank">
-        <rect width="164.99" height="60" x="20" y="300" fill="none" stroke="#000" pointer-events="all" rx="9" ry="9"/>
-        <switch transform="translate(-.5 -.5)">
-            <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-                <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:163px;height:1px;padding-top:330px;margin-left:21px">
-                    <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                        <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                            <font>
-                                <span style="font-size:20px">
-                                    Cryptosuites
-                                </span>
-                                <br/>
-                            </font>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" style="background:0 0;background-color:transparent;color-scheme:light" viewBox="-0.5 -0.5 799 701">
+    <g data-cell-id="0">
+        <g data-cell-id="1">
+            <rect width="229.99" height="250" x="547.5" y="430" fill="none" stroke="#000" stroke-dasharray="3 3" data-cell-id="_o5h41joDnnrQmcQaRRM-24" pointer-events="all" rx="34.5" ry="34.5" style="stroke:#000"/>
+            <a xlink:href="https://www.w3.org/TR/vc-json-schema/" data-cell-id="r7VOtmBWi9sTdI5Oyx6i-7" target="_blank">
+                <rect width="164.99" height="60" x="20" y="300" fill="none" stroke="#000" pointer-events="all" rx="9" ry="9" style="stroke:#000"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:163px;height:1px;padding-top:330px;margin-left:21px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <font>
+                                        <span style="font-size:20px">
+                                            Cryptosuites
+                                        </span>
+                                        <br/>
+                                    </font>
+                                </div>
+                            </div>
                         </div>
-                    </div>
-                </div>
-            </foreignObject>
-            <text xmlns="http://www.w3.org/2000/svg" x="102" y="335" font-family="Helvetica" font-size="16" text-anchor="middle">Cryptosuites
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="102" y="335" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">Cryptosuites
 </text>
-        </switch>
-    </a>
-    <rect width="164.99" height="60" x="295" y="79" fill="none" stroke="#000" pointer-events="all" rx="9" ry="9"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:163px;height:1px;padding-top:109px;margin-left:296px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <font>
-                            <span style="font-size:20px">
-                                EdDSA
-                            </span>
-                            <br/>
-                        </font>
-                        <div>
-                            <font style="font-size:13px">
-                                based on Edwards curves
-                            </font>
+                </switch>
+            </a>
+            <g data-cell-id="_o5h41joDnnrQmcQaRRM-1">
+                <rect width="164.99" height="60" x="295" y="79" fill="none" stroke="#000" pointer-events="all" rx="9" ry="9" style="stroke:#000"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:163px;height:1px;padding-top:109px;margin-left:296px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <font>
+                                        <span style="font-size:20px">
+                                            EdDSA
+                                        </span>
+                                        <br/>
+                                    </font>
+                                    <div>
+                                        <font style="font-size:13px">
+                                            based on Edwards curves
+                                        </font>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="377" y="114" font-family="Helvetica" font-size="16" text-anchor="middle">EdDSA...</text>
-    </switch>
-    <rect width="164.99" height="60" x="295" y="349" fill="none" stroke="#000" pointer-events="all" rx="9" ry="9"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:163px;height:1px;padding-top:379px;margin-left:296px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <div>
-                            <font style="font-size:20px">
-                                ECDSA
-                            </font>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="377" y="114" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">EdDSA...</text>
+                </switch>
+            </g>
+            <g data-cell-id="_o5h41joDnnrQmcQaRRM-2">
+                <rect width="164.99" height="60" x="295" y="349" fill="none" stroke="#000" pointer-events="all" rx="9" ry="9" style="stroke:#000"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:163px;height:1px;padding-top:379px;margin-left:296px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <div>
+                                        <font style="font-size:20px">
+                                            ECDSA
+                                        </font>
+                                    </div>
+                                    <div>
+                                        <font style="font-size:13px">
+                                            based on ECDSA curves
+                                        </font>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
-                        <div>
-                            <font style="font-size:13px">
-                                based on ECDSA curves
-                            </font>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="377" y="384" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">ECDSA...</text>
+                </switch>
+            </g>
+            <g data-cell-id="_o5h41joDnnrQmcQaRRM-3">
+                <rect width="164.99" height="60" x="295" y="565" fill="none" stroke="#000" pointer-events="all" rx="9" ry="9" style="stroke:#000"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:163px;height:1px;padding-top:595px;margin-left:296px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <div>
+                                        <span style="background-color:initial;font-size:20px">
+                                            BBS
+                                        </span>
+                                    </div>
+                                    <div>
+                                        <span style="background-color:initial;font-size:13px">
+                                            based on BBS schemes
+                                        </span>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="377" y="384" font-family="Helvetica" font-size="16" text-anchor="middle">ECDSA...</text>
-    </switch>
-    <rect width="164.99" height="60" x="295" y="565" fill="none" stroke="#000" pointer-events="all" rx="9" ry="9"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:163px;height:1px;padding-top:595px;margin-left:296px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <div>
-                            <span style="background-color:initial;font-size:20px">
-                                BBS
-                            </span>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="377" y="600" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">BBS...</text>
+                </switch>
+            </g>
+            <g data-cell-id="_o5h41joDnnrQmcQaRRM-9">
+                <rect width="164.99" height="70" x="580" y="560" fill="none" stroke="#000" pointer-events="all" rx="10.5" ry="10.5" style="stroke:#000" transform="matrix(1 0 0 -1 0 1190)"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:163px;height:1px;padding-top:595px;margin-left:581px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <div>
+                                        <span style="background-color:initial;font-size:20px">
+                                            bbs-2023
+                                        </span>
+                                    </div>
+                                    <div>
+                                        <span style="font-size:13px;background-color:initial">
+                                            using RDFC-1.0 for canonicalization
+                                        </span>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
-                        <div>
-                            <span style="background-color:initial;font-size:13px">
-                                based on BBS schemes
-                            </span>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="662" y="600" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">bbs-2023...</text>
+                </switch>
+            </g>
+            <g data-cell-id="_o5h41joDnnrQmcQaRRM-4">
+                <rect width="164.99" height="70" x="580" y="20" fill="none" stroke="#000" pointer-events="all" rx="10.5" ry="10.5" style="stroke:#000" transform="matrix(1 0 0 -1 0 110)"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:163px;height:1px;padding-top:55px;margin-left:581px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <div>
+                                        <span style="background-color:initial;font-size:20px">
+                                            eddsa-rdfc-2022
+                                        </span>
+                                    </div>
+                                    <div>
+                                        <span style="font-size:13px;background-color:initial">
+                                            using RDFC-1.0 for canonicalization
+                                        </span>
+                                        <br/>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="377" y="600" font-family="Helvetica" font-size="16" text-anchor="middle">BBS...</text>
-    </switch>
-    <rect width="164.99" height="70" x="580" y="560" fill="none" stroke="#000" pointer-events="all" rx="10.5" ry="10.5" transform="matrix(1 0 0 -1 0 1190)"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:163px;height:1px;padding-top:595px;margin-left:581px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <div>
-                            <span style="background-color:initial;font-size:20px">
-                                bbs-2023
-                            </span>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="662" y="60" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">eddsa-rdfc-2022...</text>
+                </switch>
+            </g>
+            <g data-cell-id="_o5h41joDnnrQmcQaRRM-5">
+                <rect width="164.99" height="70" x="580" y="128" fill="none" stroke="#000" pointer-events="all" rx="10.5" ry="10.5" style="stroke:#000" transform="matrix(1 0 0 -1 0 326)"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:163px;height:1px;padding-top:163px;margin-left:581px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <div>
+                                        <span style="background-color:initial;font-size:20px">
+                                            eddsa-jcs-2022
+                                        </span>
+                                    </div>
+                                    <div>
+                                        <span style="font-size:13px;background-color:initial">
+                                            using JCS for canonicalization
+                                        </span>
+                                        <br/>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
-                        <div>
-                            <span style="font-size:13px;background-color:initial">
-                                using RDFC-1.0 for canonicalization
-                            </span>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="662" y="168" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">eddsa-jcs-2022...</text>
+                </switch>
+            </g>
+            <g data-cell-id="_o5h41joDnnrQmcQaRRM-6">
+                <rect width="164.99" height="70" x="580" y="236" fill="none" stroke="#000" pointer-events="all" rx="10.5" ry="10.5" style="stroke:#000" transform="matrix(1 0 0 -1 0 542)"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:163px;height:1px;padding-top:271px;margin-left:581px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <div>
+                                        <span style="background-color:initial;font-size:20px">
+                                            ecdsa-rdfc-2019
+                                        </span>
+                                    </div>
+                                    <div>
+                                        <span style="font-size:13px;background-color:initial">
+                                            using RDFC-1.0 for canonicalization
+                                        </span>
+                                        <br/>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="662" y="600" font-family="Helvetica" font-size="16" text-anchor="middle">bbs-2023...</text>
-    </switch>
-    <rect width="164.99" height="70" x="580" y="20" fill="none" stroke="#000" pointer-events="all" rx="10.5" ry="10.5" transform="matrix(1 0 0 -1 0 110)"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:163px;height:1px;padding-top:55px;margin-left:581px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <div>
-                            <span style="background-color:initial;font-size:20px">
-                                eddsa-rdfc-2022
-                            </span>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="662" y="276" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">ecdsa-rdfc-2019...</text>
+                </switch>
+            </g>
+            <g data-cell-id="_o5h41joDnnrQmcQaRRM-7">
+                <rect width="164.99" height="70" x="580" y="344" fill="none" stroke="#000" pointer-events="all" rx="10.5" ry="10.5" style="stroke:#000" transform="matrix(1 0 0 -1 0 758)"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:163px;height:1px;padding-top:379px;margin-left:581px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <div>
+                                        <span style="background-color:initial;font-size:20px">
+                                            ecdsa-jcs-2019
+                                        </span>
+                                    </div>
+                                    <div>
+                                        <span style="font-size:13px;background-color:initial">
+                                            using JCS for canonicalization
+                                        </span>
+                                        <br/>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
-                        <div>
-                            <span style="font-size:13px;background-color:initial">
-                                using RDFC-1.0 for canonicalization
-                            </span>
-                            <br/>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="662" y="384" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">ecdsa-jcs-2019...</text>
+                </switch>
+            </g>
+            <g data-cell-id="_o5h41joDnnrQmcQaRRM-8">
+                <rect width="164.99" height="70" x="580" y="452" fill="none" stroke="#000" pointer-events="all" rx="10.5" ry="10.5" style="stroke:#000" transform="matrix(1 0 0 -1 0 974)"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:163px;height:1px;padding-top:487px;margin-left:581px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <div>
+                                        <span style="background-color:initial;font-size:20px">
+                                            ecdsa-sd-2023
+                                        </span>
+                                    </div>
+                                    <div>
+                                        <span style="font-size:13px;background-color:initial">
+                                            using RDFC-1.0 for canonicalization
+                                        </span>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="662" y="60" font-family="Helvetica" font-size="16" text-anchor="middle">eddsa-rdfc-2022...</text>
-    </switch>
-    <rect width="164.99" height="70" x="580" y="128" fill="none" stroke="#000" pointer-events="all" rx="10.5" ry="10.5" transform="matrix(1 0 0 -1 0 326)"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:163px;height:1px;padding-top:163px;margin-left:581px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <div>
-                            <span style="background-color:initial;font-size:20px">
-                                eddsa-jcs-2022
-                            </span>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="662" y="492" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">ecdsa-sd-2023...</text>
+                </switch>
+            </g>
+            <g stroke="#000" stroke-miterlimit="10" data-cell-id="_o5h41joDnnrQmcQaRRM-15">
+                <path fill="none" d="M184.99 330H230q10 0 10-10V119q0-10 10-10h37.13" pointer-events="stroke" style="stroke:#000"/>
+                <path d="m293.88 109-9 4.5 2.25-4.5-2.25-4.5Z" pointer-events="all" style="fill:#000;stroke:#000"/>
+            </g>
+            <g stroke="#000" stroke-miterlimit="10" data-cell-id="_o5h41joDnnrQmcQaRRM-16">
+                <path fill="none" d="M184.99 330H230q10 0 10 10v29q0 10 10 10h37.13" pointer-events="stroke" style="stroke:#000"/>
+                <path d="m293.88 379-9 4.5 2.25-4.5-2.25-4.5Z" pointer-events="all" style="fill:#000;stroke:#000"/>
+            </g>
+            <g stroke="#000" stroke-miterlimit="10" data-cell-id="_o5h41joDnnrQmcQaRRM-17">
+                <path fill="none" d="M184.99 330H230q10 0 10 10v245q0 10 10 10h37.13" pointer-events="stroke" style="stroke:#000"/>
+                <path d="m293.88 595-9 4.5 2.25-4.5-2.25-4.5Z" pointer-events="all" style="fill:#000;stroke:#000"/>
+            </g>
+            <g stroke="#000" stroke-miterlimit="10" data-cell-id="_o5h41joDnnrQmcQaRRM-18">
+                <path fill="none" d="M459.99 109H510q10 0 10-10V65q0-10 10-10h42.13" pointer-events="stroke" style="stroke:#000"/>
+                <path d="m578.88 55-9 4.5 2.25-4.5-2.25-4.5Z" pointer-events="all" style="fill:#000;stroke:#000"/>
+            </g>
+            <g stroke="#000" stroke-miterlimit="10" data-cell-id="_o5h41joDnnrQmcQaRRM-19">
+                <path fill="none" d="M459.99 109H510q10 0 10 10v34q0 10 10 10h42.13" pointer-events="stroke" style="stroke:#000"/>
+                <path d="m578.88 163-9 4.5 2.25-4.5-2.25-4.5Z" pointer-events="all" style="fill:#000;stroke:#000"/>
+            </g>
+            <g stroke="#000" stroke-miterlimit="10" data-cell-id="_o5h41joDnnrQmcQaRRM-20">
+                <path fill="none" d="M459.99 379H510q10 0 10-10v-88q0-10 10-10h42.13" pointer-events="stroke" style="stroke:#000"/>
+                <path d="m578.88 271-9 4.5 2.25-4.5-2.25-4.5Z" pointer-events="all" style="fill:#000;stroke:#000"/>
+            </g>
+            <g stroke="#000" stroke-miterlimit="10" data-cell-id="_o5h41joDnnrQmcQaRRM-21">
+                <path fill="none" d="M459.99 379H510q10 0 10 10v88q0 10 10 10h42.13" pointer-events="stroke" style="stroke:#000"/>
+                <path d="m578.88 487-9 4.5 2.25-4.5-2.25-4.5Z" pointer-events="all" style="fill:#000;stroke:#000"/>
+            </g>
+            <g stroke="#000" stroke-miterlimit="10" data-cell-id="_o5h41joDnnrQmcQaRRM-22">
+                <path fill="none" d="M459.99 379H572.13" pointer-events="stroke" style="stroke:#000"/>
+                <path d="m578.88 379-9 4.5 2.25-4.5-2.25-4.5Z" pointer-events="all" style="fill:#000;stroke:#000"/>
+            </g>
+            <g stroke="#000" stroke-miterlimit="10" data-cell-id="_o5h41joDnnrQmcQaRRM-23">
+                <path fill="none" d="M459.99 595H572.13" pointer-events="stroke" style="stroke:#000"/>
+                <path d="m578.88 595-9 4.5 2.25-4.5-2.25-4.5Z" pointer-events="all" style="fill:#000;stroke:#000"/>
+            </g>
+            <g data-cell-id="XB48tUagIdPG_h6vu15s-1">
+                <rect width="220" height="30" x="552.49" y="650" fill="none" pointer-events="all"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:665px;margin-left:662px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:15px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
+                                    <i>
+                                        Selective disclosure schemes
+                                    </i>
+                                </div>
+                            </div>
                         </div>
-                        <div>
-                            <span style="font-size:13px;background-color:initial">
-                                using JCS for canonicalization
-                            </span>
-                            <br/>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="662" y="168" font-family="Helvetica" font-size="16" text-anchor="middle">eddsa-jcs-2022...</text>
-    </switch>
-    <rect width="164.99" height="70" x="580" y="236" fill="none" stroke="#000" pointer-events="all" rx="10.5" ry="10.5" transform="matrix(1 0 0 -1 0 542)"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:163px;height:1px;padding-top:271px;margin-left:581px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <div>
-                            <span style="background-color:initial;font-size:20px">
-                                ecdsa-rdfc-2019
-                            </span>
-                        </div>
-                        <div>
-                            <span style="font-size:13px;background-color:initial">
-                                using RDFC-1.0 for canonicalization
-                            </span>
-                            <br/>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="662" y="276" font-family="Helvetica" font-size="16" text-anchor="middle">ecdsa-rdfc-2019...</text>
-    </switch>
-    <rect width="164.99" height="70" x="580" y="344" fill="none" stroke="#000" pointer-events="all" rx="10.5" ry="10.5" transform="matrix(1 0 0 -1 0 758)"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:163px;height:1px;padding-top:379px;margin-left:581px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <div>
-                            <span style="background-color:initial;font-size:20px">
-                                ecdsa-jcs-2019
-                            </span>
-                        </div>
-                        <div>
-                            <span style="font-size:13px;background-color:initial">
-                                using JCS for canonicalization
-                            </span>
-                            <br/>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="662" y="384" font-family="Helvetica" font-size="16" text-anchor="middle">ecdsa-jcs-2019...</text>
-    </switch>
-    <rect width="164.99" height="70" x="580" y="452" fill="none" stroke="#000" pointer-events="all" rx="10.5" ry="10.5" transform="matrix(1 0 0 -1 0 974)"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:163px;height:1px;padding-top:487px;margin-left:581px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <div>
-                            <span style="background-color:initial;font-size:20px">
-                                ecdsa-sd-2023
-                            </span>
-                        </div>
-                        <div>
-                            <span style="font-size:13px;background-color:initial">
-                                using RDFC-1.0 for canonicalization
-                            </span>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="662" y="492" font-family="Helvetica" font-size="16" text-anchor="middle">ecdsa-sd-2023...</text>
-    </switch>
-    <g stroke="#000" stroke-miterlimit="10">
-        <path fill="none" d="M184.99 330H230q10 0 10-10V119q0-10 10-10h37.13" pointer-events="stroke"/>
-        <path d="m293.88 109-9 4.5 2.25-4.5-2.25-4.5Z" pointer-events="all"/>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="662" y="670" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="15" text-anchor="middle">Selective disclosure schemes</text>
+                </switch>
+            </g>
+        </g>
     </g>
-    <g stroke="#000" stroke-miterlimit="10">
-        <path fill="none" d="M184.99 330H230q10 0 10 10v29q0 10 10 10h37.13" pointer-events="stroke"/>
-        <path d="m293.88 379-9 4.5 2.25-4.5-2.25-4.5Z" pointer-events="all"/>
-    </g>
-    <g stroke="#000" stroke-miterlimit="10">
-        <path fill="none" d="M184.99 330H230q10 0 10 10v245q0 10 10 10h37.13" pointer-events="stroke"/>
-        <path d="m293.88 595-9 4.5 2.25-4.5-2.25-4.5Z" pointer-events="all"/>
-    </g>
-    <g stroke="#000" stroke-miterlimit="10">
-        <path fill="none" d="M459.99 109H510q10 0 10-10V65q0-10 10-10h42.13" pointer-events="stroke"/>
-        <path d="m578.88 55-9 4.5 2.25-4.5-2.25-4.5Z" pointer-events="all"/>
-    </g>
-    <g stroke="#000" stroke-miterlimit="10">
-        <path fill="none" d="M459.99 109H510q10 0 10 10v34q0 10 10 10h42.13" pointer-events="stroke"/>
-        <path d="m578.88 163-9 4.5 2.25-4.5-2.25-4.5Z" pointer-events="all"/>
-    </g>
-    <g stroke="#000" stroke-miterlimit="10">
-        <path fill="none" d="M459.99 379H510q10 0 10-10v-88q0-10 10-10h42.13" pointer-events="stroke"/>
-        <path d="m578.88 271-9 4.5 2.25-4.5-2.25-4.5Z" pointer-events="all"/>
-    </g>
-    <g stroke="#000" stroke-miterlimit="10">
-        <path fill="none" d="M459.99 379H510q10 0 10 10v88q0 10 10 10h42.13" pointer-events="stroke"/>
-        <path d="m578.88 487-9 4.5 2.25-4.5-2.25-4.5Z" pointer-events="all"/>
-    </g>
-    <g stroke="#000" stroke-miterlimit="10">
-        <path fill="none" d="M459.99 379H572.13" pointer-events="stroke"/>
-        <path d="m578.88 379-9 4.5 2.25-4.5-2.25-4.5Z" pointer-events="all"/>
-    </g>
-    <g stroke="#000" stroke-miterlimit="10">
-        <path fill="none" d="M459.99 595H572.13" pointer-events="stroke"/>
-        <path d="m578.88 595-9 4.5 2.25-4.5-2.25-4.5Z" pointer-events="all"/>
-    </g>
-    <rect width="220" height="40" x="555.01" y="650" fill="none" pointer-events="all" rx="6" ry="6"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe flex-start;justify-content:unsafe center;width:218px;height:1px;padding-top:657px;margin-left:556px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <i style="border-color:var(--border-color);color:#000;font-family:Helvetica;font-variant-ligatures:normal;font-variant-caps:normal;font-weight:400;letter-spacing:normal;orphans:2;text-indent:0;text-transform:none;widows:2;word-spacing:0;-webkit-text-stroke-width:0;background-color:#fbfbfb;text-decoration-thickness:initial;text-decoration-style:initial;text-decoration-color:initial">
-                            <font style="font-size:15px">
-                                Selective disclosure schemes
-                            </font>
-                        </i>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="665" y="673" font-family="Helvetica" font-size="16" text-anchor="middle">Selective disclosure schemes</text>
-    </switch>
 </svg>

--- a/diagrams/diagrams.md
+++ b/diagrams/diagrams.md
@@ -1,3 +1,23 @@
 # Generation of the diagrams
 
 Some of the diagrams are, originally, in the [draw.io](https://www.drawio.com/) format. _Any change on those diagrams must be made by modifying the files in this directory._  The editing application can be downloaded and used directly, or added to Google Docs. Note that, due to some bug(s) in the software, and to improve the exported SVG file, it must be run through a [post-processing script](https://github.com/iherman/drawio-svg/), which must be downloaded and run separately.
+
+When editing the diagram in draw.io
+- Under "Diagram" no background color
+
+When creating/updating a diagram in SVG from draw.io:
+- Export to SVG with 
+  - zoom 100%
+  - border width: 20
+  - size: diagram
+  - transparent background
+  - appearance: light
+  - no shadow
+  - no copy of my diagram
+  - no embed images
+  - no embed fonts
+  - link automatic
+
+then run draw-svg (this cleans up the header to make the image scalable).
+
+The dark/light mode of draw.io only creates difficulties; the W3C stye automatically sets a background to white (there is an entry in CSS to make it "less" white).

--- a/diagrams/ecosystem.drawio
+++ b/diagrams/ecosystem.drawio
@@ -1,6 +1,6 @@
-<mxfile host="Electron" modified="2024-04-26T09:50:52.092Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/24.2.5 Chrome/120.0.6099.109 Electron/28.1.0 Safari/537.36" etag="wdcRkjxStZtqNYiYFqpO" version="24.2.5" type="device">
+<mxfile host="Electron" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/26.2.15 Chrome/134.0.6998.205 Electron/35.2.1 Safari/537.36" version="26.2.15">
   <diagram name="Page-1" id="ZRe_wIOORr0k_d4isBBX">
-    <mxGraphModel dx="2801" dy="2060" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
+    <mxGraphModel dx="2329" dy="1862" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
@@ -25,9 +25,9 @@
             <mxPoint x="-727" y="-550" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="CqYlGcgU1QHX9f7NfkNa-12" value="&lt;font style=&quot;font-size: 15px;&quot;&gt;Issue Credentials&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=12;" parent="CqYlGcgU1QHX9f7NfkNa-11" vertex="1" connectable="0">
-          <mxGeometry x="-0.1789" y="1" relative="1" as="geometry">
-            <mxPoint as="offset" />
+        <mxCell id="oT-2gYkduoHVvo-qYq7K-6" value="&lt;font style=&quot;font-size: 17px;&quot;&gt;Issue Credentials&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=12;labelBackgroundColor=none;" vertex="1" connectable="0" parent="CqYlGcgU1QHX9f7NfkNa-11">
+          <mxGeometry x="-0.0941" y="-1" relative="1" as="geometry">
+            <mxPoint x="-6" y="-1" as="offset" />
           </mxGeometry>
         </mxCell>
         <mxCell id="CqYlGcgU1QHX9f7NfkNa-13" value="" style="shape=flexArrow;endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=9.67;curved=1;width=26;entryX=0;entryY=0.5;entryDx=0;entryDy=0;" parent="1" edge="1">
@@ -36,9 +36,9 @@
             <mxPoint x="-398" y="-554.5" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="CqYlGcgU1QHX9f7NfkNa-14" value="&lt;font style=&quot;font-size: 15px;&quot;&gt;Send Presentation&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=12;" parent="CqYlGcgU1QHX9f7NfkNa-13" vertex="1" connectable="0">
-          <mxGeometry x="-0.1789" y="1" relative="1" as="geometry">
-            <mxPoint as="offset" />
+        <mxCell id="oT-2gYkduoHVvo-qYq7K-5" value="Send Presentation" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;labelBackgroundColor=none;" vertex="1" connectable="0" parent="CqYlGcgU1QHX9f7NfkNa-13">
+          <mxGeometry x="-0.1177" y="-1" relative="1" as="geometry">
+            <mxPoint x="-3" y="-2" as="offset" />
           </mxGeometry>
         </mxCell>
       </root>

--- a/diagrams/ecosystem.svg
+++ b/diagrams/ecosystem.svg
@@ -1,116 +1,128 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-0.5 -0.5 864 123">
-    <rect width="151" height="70" x="370" y="21" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="10.5" ry="10.5"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:149px;height:1px;padding-top:56px;margin-left:371px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <div>
-                            <font style="font-size:16px">
-                                <i>
-                                    <b>
-                                        Holder
-                                    </b>
-                                </i>
-                            </font>
+<svg xmlns="http://www.w3.org/2000/svg" style="background:0 0;background-color:transparent;color-scheme:light" viewBox="-0.5 -0.5 864 123">
+    <g data-cell-id="0">
+        <g data-cell-id="1">
+            <g data-cell-id="CqYlGcgU1QHX9f7NfkNa-4">
+                <rect width="151" height="70" x="370" y="21" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="10.5" ry="10.5" style="stroke:#000"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:149px;height:1px;padding-top:56px;margin-left:371px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:12px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <div>
+                                        <font style="font-size:16px">
+                                            <i>
+                                                <b>
+                                                    Holder
+                                                </b>
+                                            </i>
+                                        </font>
+                                    </div>
+                                    <div>
+                                        <font style="font-size:16px">
+                                            <i>
+                                                Acquires, stores, presents VCs
+                                            </i>
+                                        </font>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
-                        <div>
-                            <font style="font-size:16px">
-                                <i>
-                                    Acquires, stores, presents VCs
-                                </i>
-                            </font>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="446" y="60" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12" text-anchor="middle">Holder...</text>
+                </switch>
+            </g>
+            <g data-cell-id="CqYlGcgU1QHX9f7NfkNa-5">
+                <rect width="151" height="70" x="691" y="21" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="10.5" ry="10.5" style="stroke:#000"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:149px;height:1px;padding-top:56px;margin-left:692px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:12px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <div>
+                                        <span style="font-size:16px">
+                                            <b>
+                                                <i>
+                                                    Verifier
+                                                </i>
+                                            </b>
+                                        </span>
+                                    </div>
+                                    <div>
+                                        <font style="font-size:16px">
+                                            <i>
+                                                Verifies VCs
+                                            </i>
+                                        </font>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="446" y="60" font-family="Helvetica" font-size="12" text-anchor="middle">Holder...</text>
-    </switch>
-    <rect width="151" height="70" x="691" y="21" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="10.5" ry="10.5"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:149px;height:1px;padding-top:56px;margin-left:692px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <div>
-                            <span style="font-size:16px">
-                                <b>
-                                    <i>
-                                        Verifier
-                                    </i>
-                                </b>
-                            </span>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="767" y="60" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12" text-anchor="middle">Verifier...</text>
+                </switch>
+            </g>
+            <g data-cell-id="CqYlGcgU1QHX9f7NfkNa-6">
+                <rect width="151" height="70" x="49" y="21" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="10.5" ry="10.5" style="stroke:#000"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:149px;height:1px;padding-top:56px;margin-left:50px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:12px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <div>
+                                        <span style="font-size:16px">
+                                            <b>
+                                                <i>
+                                                    Issuer
+                                                </i>
+                                            </b>
+                                        </span>
+                                    </div>
+                                    <div>
+                                        <font style="font-size:16px">
+                                            <i>
+                                                Issues VCs
+                                            </i>
+                                        </font>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
-                        <div>
-                            <font style="font-size:16px">
-                                <i>
-                                    Verifies VCs
-                                </i>
-                            </font>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="125" y="60" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12" text-anchor="middle">Issuer...</text>
+                </switch>
+            </g>
+            <g data-cell-id="CqYlGcgU1QHX9f7NfkNa-11">
+                <path fill="none" stroke="#000" stroke-miterlimit="10" d="M200.5 69V43h138.99V32.5L369.5 56l-30.01 23.5V69Z" pointer-events="all" style="stroke:#000"/>
+                <switch data-cell-id="oT-2gYkduoHVvo-qYq7K-6" transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:57px;margin-left:272px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:12px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
+                                    <font style="font-size:17px">
+                                        Issue Credentials
+                                    </font>
+                                </div>
+                            </div>
                         </div>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="767" y="60" font-family="Helvetica" font-size="12" text-anchor="middle">Verifier...</text>
-    </switch>
-    <rect width="151" height="70" x="49" y="21" fill="none" stroke="#000" stroke-width="2" pointer-events="all" rx="10.5" ry="10.5"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:149px;height:1px;padding-top:56px;margin-left:50px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <div>
-                            <span style="font-size:16px">
-                                <b>
-                                    <i>
-                                        Issuer
-                                    </i>
-                                </b>
-                            </span>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="272" y="60" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12" text-anchor="middle">Issue Credentials</text>
+                </switch>
+            </g>
+            <g data-cell-id="CqYlGcgU1QHX9f7NfkNa-13">
+                <path fill="none" stroke="#000" stroke-miterlimit="10" d="m521.54 70-.08-26 138.99-.41-.03-10.5L690.5 56.5l-29.94 23.59-.03-10.5Z" pointer-events="all" style="stroke:#000"/>
+                <switch data-cell-id="oT-2gYkduoHVvo-qYq7K-5" transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:56px;margin-left:594px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
+                                    Send Presentation
+                                </div>
+                            </div>
                         </div>
-                        <div>
-                            <font style="font-size:16px">
-                                <i>
-                                    Issues VCs
-                                </i>
-                            </font>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="125" y="60" font-family="Helvetica" font-size="12" text-anchor="middle">Issuer...</text>
-    </switch>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" d="M200.5 69V43h138.99V32.5L369.5 56l-30.01 23.5V69Z" pointer-events="all"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:56px;margin-left:271px">
-                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
-                        <font style="font-size:15px">
-                            Issue Credentials
-                        </font>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="271" y="59" font-family="Helvetica" font-size="12" text-anchor="middle">Issue Credentials</text>
-    </switch>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" d="m521.54 70-.08-26 138.99-.41-.03-10.5L690.5 56.5l-29.94 23.59-.03-10.5Z" pointer-events="all"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:56px;margin-left:591px">
-                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
-                        <font style="font-size:15px">
-                            Send Presentation
-                        </font>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="591" y="60" font-family="Helvetica" font-size="12" text-anchor="middle">Send Presentation</text>
-    </switch>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="594" y="61" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">Send Presentation</text>
+                </switch>
+            </g>
+        </g>
+    </g>
 </svg>

--- a/diagrams/ecosystemdetail.drawio
+++ b/diagrams/ecosystemdetail.drawio
@@ -1,6 +1,6 @@
-<mxfile host="Electron" modified="2024-02-22T10:39:37.771Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/23.0.2 Chrome/120.0.6099.109 Electron/28.1.0 Safari/537.36" etag="z_4pgMkUS2etdIXSzCbY" version="23.0.2" type="device">
+<mxfile host="Electron" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/26.2.15 Chrome/134.0.6998.205 Electron/35.2.1 Safari/537.36" version="26.2.15">
   <diagram name="Page-1" id="6gULVhWcurzz5zKnDaAR">
-    <mxGraphModel dx="1365" dy="1311" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
+    <mxGraphModel dx="1059" dy="884" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
@@ -20,9 +20,9 @@
             <mxPoint x="530" y="280" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="WkVDoU_EPi6P_C-XghKi-13" value="&amp;nbsp;&lt;b&gt;Issue&lt;/b&gt;&lt;br&gt;&amp;nbsp;&lt;font style=&quot;font-size: 12px;&quot;&gt;exactly once&lt;/font&gt;&amp;nbsp;&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;labelBackgroundColor=default;" parent="WkVDoU_EPi6P_C-XghKi-12" vertex="1" connectable="0">
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-13" value="&amp;nbsp;&lt;b&gt;Issue&lt;/b&gt;&lt;br&gt;&amp;nbsp;&lt;font style=&quot;font-size: 12px;&quot;&gt;exactly once&lt;/font&gt;&amp;nbsp;&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;labelBackgroundColor=none;" parent="WkVDoU_EPi6P_C-XghKi-12" vertex="1" connectable="0">
           <mxGeometry x="-0.0577" y="4" relative="1" as="geometry">
-            <mxPoint as="offset" />
+            <mxPoint x="-20" y="-22" as="offset" />
           </mxGeometry>
         </mxCell>
         <mxCell id="WkVDoU_EPi6P_C-XghKi-14" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=1;exitY=0.5;exitDx=0;exitDy=0;entryX=0;entryY=0.25;entryDx=0;entryDy=0;labelBackgroundColor=none;fontColor=default;" parent="1" source="4crVNhUSypmRE79kbWuG-14" edge="1">
@@ -31,9 +31,9 @@
             <mxPoint x="810" y="402.5" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="WkVDoU_EPi6P_C-XghKi-15" value="&amp;nbsp;&lt;b&gt;Present&lt;/b&gt;&amp;nbsp;&lt;br&gt;&lt;font style=&quot;font-size: 12px;&quot;&gt;&amp;nbsp;repeatable&amp;nbsp;&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;labelBackgroundColor=default;" parent="WkVDoU_EPi6P_C-XghKi-14" vertex="1" connectable="0">
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-15" value="&amp;nbsp;&lt;b&gt;Present&lt;/b&gt;&amp;nbsp;&lt;br&gt;&lt;font style=&quot;font-size: 12px;&quot;&gt;&amp;nbsp;repeatable&amp;nbsp;&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;labelBackgroundColor=none;" parent="WkVDoU_EPi6P_C-XghKi-14" vertex="1" connectable="0">
           <mxGeometry x="0.0141" relative="1" as="geometry">
-            <mxPoint as="offset" />
+            <mxPoint x="36" y="-17" as="offset" />
           </mxGeometry>
         </mxCell>
         <mxCell id="WkVDoU_EPi6P_C-XghKi-16" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=1;entryY=0.5;entryDx=0;entryDy=0;exitX=0;exitY=0.5;exitDx=0;exitDy=0;labelBackgroundColor=none;fontColor=default;" parent="1" target="r7VOtmBWi9sTdI5Oyx6i-1" edge="1">
@@ -42,9 +42,9 @@
             <mxPoint x="480" y="440" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="WkVDoU_EPi6P_C-XghKi-17" value="&lt;b&gt;&amp;nbsp;Check Status&amp;nbsp;&lt;br&gt;&lt;/b&gt;&amp;nbsp;&lt;font style=&quot;font-size: 12px;&quot;&gt;might NOT preserve privacy, repeatable&amp;nbsp;&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;labelBackgroundColor=default;" parent="WkVDoU_EPi6P_C-XghKi-16" vertex="1" connectable="0">
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-17" value="&lt;b&gt;&amp;nbsp;Check Status&amp;nbsp;&lt;br&gt;&lt;/b&gt;&amp;nbsp;&lt;font style=&quot;font-size: 12px;&quot;&gt;might NOT preserve privacy, repeatable&amp;nbsp;&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;labelBackgroundColor=none;" parent="WkVDoU_EPi6P_C-XghKi-16" vertex="1" connectable="0">
           <mxGeometry x="-0.0144" y="2" relative="1" as="geometry">
-            <mxPoint x="1" y="-5" as="offset" />
+            <mxPoint x="-66" y="-26" as="offset" />
           </mxGeometry>
         </mxCell>
         <mxCell id="WkVDoU_EPi6P_C-XghKi-18" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;exitX=0.75;exitY=1;exitDx=0;exitDy=0;entryX=0;entryY=0.5;entryDx=0;entryDy=0;dashed=1;labelBackgroundColor=none;fontColor=default;" parent="1" source="r7VOtmBWi9sTdI5Oyx6i-1" target="WkVDoU_EPi6P_C-XghKi-11" edge="1">
@@ -53,9 +53,9 @@
             <mxPoint x="480" y="440" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="WkVDoU_EPi6P_C-XghKi-19" value="&lt;b&gt;&amp;nbsp;Revoke&amp;nbsp;&lt;br&gt;&lt;/b&gt;&amp;nbsp;&lt;font style=&quot;font-size: 12px;&quot;&gt;up to once&lt;/font&gt;&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;labelBackgroundColor=default;" parent="WkVDoU_EPi6P_C-XghKi-18" vertex="1" connectable="0">
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-19" value="&lt;b&gt;&amp;nbsp;Revoke&amp;nbsp;&lt;br&gt;&lt;/b&gt;&amp;nbsp;&lt;font style=&quot;font-size: 12px;&quot;&gt;up to once&lt;/font&gt;&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;labelBackgroundColor=none;" parent="WkVDoU_EPi6P_C-XghKi-18" vertex="1" connectable="0">
           <mxGeometry x="-0.0007" y="-2" relative="1" as="geometry">
-            <mxPoint as="offset" />
+            <mxPoint x="18" y="50" as="offset" />
           </mxGeometry>
         </mxCell>
         <mxCell id="WkVDoU_EPi6P_C-XghKi-20" value="" style="curved=1;endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;exitX=0;exitY=0.75;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;labelBackgroundColor=none;fontColor=default;" parent="1" target="WkVDoU_EPi6P_C-XghKi-11" edge="1">
@@ -67,9 +67,9 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="WkVDoU_EPi6P_C-XghKi-21" value="&lt;b&gt;&amp;nbsp;Check Status&amp;nbsp;&lt;br&gt;&lt;/b&gt;&amp;nbsp;&lt;font style=&quot;font-size: 12px;&quot;&gt;MIGHT preserve privacy, repeatable&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;labelBackgroundColor=default;" parent="WkVDoU_EPi6P_C-XghKi-20" vertex="1" connectable="0">
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-21" value="&lt;b&gt;&amp;nbsp;Check Status&amp;nbsp;&lt;br&gt;&lt;/b&gt;&amp;nbsp;&lt;font style=&quot;font-size: 12px;&quot;&gt;MIGHT preserve privacy,&amp;nbsp;&lt;/font&gt;&lt;div&gt;&lt;font style=&quot;font-size: 12px;&quot;&gt;repeatable&lt;/font&gt;&lt;/div&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;labelBackgroundColor=none;" parent="WkVDoU_EPi6P_C-XghKi-20" vertex="1" connectable="0">
           <mxGeometry x="0.0976" y="18" relative="1" as="geometry">
-            <mxPoint x="-1" as="offset" />
+            <mxPoint x="-89" y="6" as="offset" />
           </mxGeometry>
         </mxCell>
         <mxCell id="WkVDoU_EPi6P_C-XghKi-23" value="" style="curved=1;endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;exitX=0.25;exitY=1;exitDx=0;exitDy=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;labelBackgroundColor=none;fontColor=default;" parent="1" source="4crVNhUSypmRE79kbWuG-3" target="WkVDoU_EPi6P_C-XghKi-11" edge="1">
@@ -82,13 +82,13 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="WkVDoU_EPi6P_C-XghKi-24" value="&lt;b&gt;&amp;nbsp;Verify&amp;nbsp;&lt;br&gt;&lt;/b&gt;&amp;nbsp;&lt;font style=&quot;font-size: 12px;&quot;&gt;repeatable&lt;/font&gt;&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;labelBackgroundColor=default;" parent="WkVDoU_EPi6P_C-XghKi-23" vertex="1" connectable="0">
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-24" value="&lt;b&gt;&amp;nbsp;Verify&amp;nbsp;&lt;br&gt;&lt;/b&gt;&amp;nbsp;&lt;font style=&quot;font-size: 12px;&quot;&gt;repeatable&lt;/font&gt;&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;labelBackgroundColor=none;" parent="WkVDoU_EPi6P_C-XghKi-23" vertex="1" connectable="0">
           <mxGeometry x="-0.0198" y="-16" relative="1" as="geometry">
-            <mxPoint x="12" y="6" as="offset" />
+            <mxPoint x="29" y="35" as="offset" />
           </mxGeometry>
         </mxCell>
         <mxCell id="WkVDoU_EPi6P_C-XghKi-30" value="" style="shape=lineEllipse;perimeter=ellipsePerimeter;whiteSpace=wrap;html=1;backgroundOutline=1;fontSize=16;rotation=-35;strokeWidth=6;fillColor=none;labelBackgroundColor=none;" parent="1" vertex="1">
-          <mxGeometry x="320" y="130" width="32.63" height="32.63" as="geometry" />
+          <mxGeometry x="302.62" y="150" width="32.63" height="32.63" as="geometry" />
         </mxCell>
         <mxCell id="WkVDoU_EPi6P_C-XghKi-31" value="" style="endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;curved=1;entryX=1;entryY=1;entryDx=0;entryDy=0;exitX=0;exitY=0.5;exitDx=0;exitDy=0;targetPerimeterSpacing=-6;dashed=1;labelBackgroundColor=none;fontColor=default;" parent="1" target="WkVDoU_EPi6P_C-XghKi-30" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
@@ -96,9 +96,9 @@
             <mxPoint x="380" y="219" as="targetPoint" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="WkVDoU_EPi6P_C-XghKi-32" value="&amp;nbsp;&lt;b&gt;Delete&lt;/b&gt;&amp;nbsp;&lt;br&gt;&amp;nbsp;&lt;font style=&quot;font-size: 12px;&quot;&gt;up to once per Holder&lt;/font&gt;&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;labelBackgroundColor=default;" parent="WkVDoU_EPi6P_C-XghKi-31" vertex="1" connectable="0">
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-32" value="&amp;nbsp;&lt;b&gt;Delete&lt;/b&gt;&amp;nbsp;&lt;br&gt;&amp;nbsp;&lt;font style=&quot;font-size: 12px;&quot;&gt;up to once per Holder&lt;/font&gt;&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;labelBackgroundColor=none;" parent="WkVDoU_EPi6P_C-XghKi-31" vertex="1" connectable="0">
           <mxGeometry x="0.0517" y="1" relative="1" as="geometry">
-            <mxPoint as="offset" />
+            <mxPoint x="43" y="-27" as="offset" />
           </mxGeometry>
         </mxCell>
         <mxCell id="WkVDoU_EPi6P_C-XghKi-25" value="" style="curved=1;endArrow=classic;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;entryX=1;entryY=0;entryDx=0;entryDy=0;labelBackgroundColor=none;fontColor=default;" parent="1" edge="1">
@@ -112,20 +112,20 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="WkVDoU_EPi6P_C-XghKi-27" value="&amp;nbsp;&lt;b&gt;Transfer&lt;/b&gt;&lt;br&gt;&amp;nbsp;&lt;font style=&quot;font-size: 12px;&quot;&gt;repeatable&lt;/font&gt;&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;labelBackgroundColor=default;" parent="WkVDoU_EPi6P_C-XghKi-25" vertex="1" connectable="0">
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-27" value="&amp;nbsp;&lt;b&gt;Transfer&lt;/b&gt;&lt;br&gt;&amp;nbsp;&lt;font style=&quot;font-size: 12px;&quot;&gt;repeatable&lt;/font&gt;&amp;nbsp;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;labelBackgroundColor=none;" parent="WkVDoU_EPi6P_C-XghKi-25" vertex="1" connectable="0">
           <mxGeometry x="0.335" y="-1" relative="1" as="geometry">
-            <mxPoint x="-13" y="1" as="offset" />
+            <mxPoint x="-45" y="-58" as="offset" />
           </mxGeometry>
         </mxCell>
-        <mxCell id="4crVNhUSypmRE79kbWuG-12" value="" style="group" vertex="1" connectable="0" parent="1">
+        <mxCell id="4crVNhUSypmRE79kbWuG-12" value="" style="group" parent="1" vertex="1" connectable="0">
           <mxGeometry x="810" y="390" width="156.25" height="88" as="geometry" />
         </mxCell>
         <UserObject label="&lt;font style=&quot;&quot;&gt;&lt;span style=&quot;font-size: 20px;&quot;&gt;Verifiers&lt;/span&gt;&lt;/font&gt;" linkTarget="_blank" id="4crVNhUSypmRE79kbWuG-3">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;labelBackgroundColor=none;fillColor=none;" vertex="1" parent="4crVNhUSypmRE79kbWuG-12">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;labelBackgroundColor=none;fillColor=none;" parent="4crVNhUSypmRE79kbWuG-12" vertex="1">
             <mxGeometry x="31" y="30" width="125.25" height="58" as="geometry" />
           </mxCell>
         </UserObject>
-        <mxCell id="4crVNhUSypmRE79kbWuG-9" value="" style="curved=1;endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;endFill=0;arcSize=20;exitX=-0.008;exitY=0.845;exitDx=0;exitDy=0;exitPerimeter=0;" edge="1" parent="4crVNhUSypmRE79kbWuG-12" source="4crVNhUSypmRE79kbWuG-3">
+        <mxCell id="4crVNhUSypmRE79kbWuG-9" value="" style="curved=1;endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;endFill=0;arcSize=20;exitX=-0.008;exitY=0.845;exitDx=0;exitDy=0;exitPerimeter=0;" parent="4crVNhUSypmRE79kbWuG-12" source="4crVNhUSypmRE79kbWuG-3" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="30" y="79" as="sourcePoint" />
             <mxPoint x="150" y="30" as="targetPoint" />
@@ -140,7 +140,7 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="4crVNhUSypmRE79kbWuG-10" value="" style="curved=1;endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;endFill=0;arcSize=20;" edge="1" parent="4crVNhUSypmRE79kbWuG-12">
+        <mxCell id="4crVNhUSypmRE79kbWuG-10" value="" style="curved=1;endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;endFill=0;arcSize=20;" parent="4crVNhUSypmRE79kbWuG-12" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="20" y="69" as="sourcePoint" />
             <mxPoint x="140" y="20" as="targetPoint" />
@@ -155,7 +155,7 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="4crVNhUSypmRE79kbWuG-11" value="" style="curved=1;endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;endFill=0;arcSize=20;" edge="1" parent="4crVNhUSypmRE79kbWuG-12">
+        <mxCell id="4crVNhUSypmRE79kbWuG-11" value="" style="curved=1;endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;endFill=0;arcSize=20;" parent="4crVNhUSypmRE79kbWuG-12" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="10" y="59" as="sourcePoint" />
             <mxPoint x="130" y="10" as="targetPoint" />
@@ -170,15 +170,15 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="4crVNhUSypmRE79kbWuG-13" value="" style="group" vertex="1" connectable="0" parent="1">
+        <mxCell id="4crVNhUSypmRE79kbWuG-13" value="" style="group" parent="1" vertex="1" connectable="0">
           <mxGeometry x="520" y="210" width="156.25" height="88" as="geometry" />
         </mxCell>
         <UserObject label="&lt;font style=&quot;&quot;&gt;&lt;span style=&quot;font-size: 20px;&quot;&gt;Holders&lt;/span&gt;&lt;/font&gt;" linkTarget="_blank" id="4crVNhUSypmRE79kbWuG-14">
-          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;labelBackgroundColor=none;fillColor=none;" vertex="1" parent="4crVNhUSypmRE79kbWuG-13">
+          <mxCell style="rounded=1;whiteSpace=wrap;html=1;fontSize=16;labelBackgroundColor=none;fillColor=none;" parent="4crVNhUSypmRE79kbWuG-13" vertex="1">
             <mxGeometry x="31" y="30" width="125.25" height="58" as="geometry" />
           </mxCell>
         </UserObject>
-        <mxCell id="4crVNhUSypmRE79kbWuG-15" value="" style="curved=1;endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;endFill=0;arcSize=20;exitX=-0.008;exitY=0.845;exitDx=0;exitDy=0;exitPerimeter=0;" edge="1" parent="4crVNhUSypmRE79kbWuG-13" source="4crVNhUSypmRE79kbWuG-14">
+        <mxCell id="4crVNhUSypmRE79kbWuG-15" value="" style="curved=1;endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;endFill=0;arcSize=20;exitX=-0.008;exitY=0.845;exitDx=0;exitDy=0;exitPerimeter=0;" parent="4crVNhUSypmRE79kbWuG-13" source="4crVNhUSypmRE79kbWuG-14" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="30" y="79" as="sourcePoint" />
             <mxPoint x="150" y="30" as="targetPoint" />
@@ -193,7 +193,7 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="4crVNhUSypmRE79kbWuG-16" value="" style="curved=1;endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;endFill=0;arcSize=20;" edge="1" parent="4crVNhUSypmRE79kbWuG-13">
+        <mxCell id="4crVNhUSypmRE79kbWuG-16" value="" style="curved=1;endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;endFill=0;arcSize=20;" parent="4crVNhUSypmRE79kbWuG-13" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="20" y="69" as="sourcePoint" />
             <mxPoint x="140" y="20" as="targetPoint" />
@@ -208,7 +208,7 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="4crVNhUSypmRE79kbWuG-17" value="" style="curved=1;endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;endFill=0;arcSize=20;" edge="1" parent="4crVNhUSypmRE79kbWuG-13">
+        <mxCell id="4crVNhUSypmRE79kbWuG-17" value="" style="curved=1;endArrow=none;html=1;rounded=0;fontSize=12;startSize=8;endSize=8;endFill=0;arcSize=20;" parent="4crVNhUSypmRE79kbWuG-13" edge="1">
           <mxGeometry width="50" height="50" relative="1" as="geometry">
             <mxPoint x="10" y="59" as="sourcePoint" />
             <mxPoint x="130" y="10" as="targetPoint" />
@@ -234,9 +234,9 @@
             </Array>
           </mxGeometry>
         </mxCell>
-        <mxCell id="WkVDoU_EPi6P_C-XghKi-29" value="&lt;b&gt;&amp;nbsp;Verify and Validate&amp;nbsp;&lt;br&gt;&lt;/b&gt;&lt;font style=&quot;font-size: 12px;&quot;&gt;&amp;nbsp;repeatable&amp;nbsp;&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;labelBackgroundColor=default;" parent="WkVDoU_EPi6P_C-XghKi-28" vertex="1" connectable="0">
+        <mxCell id="WkVDoU_EPi6P_C-XghKi-29" value="&lt;b&gt;&amp;nbsp;Verify and Validate&amp;nbsp;&lt;br&gt;&lt;/b&gt;&lt;font style=&quot;font-size: 12px;&quot;&gt;&amp;nbsp;repeatable&amp;nbsp;&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];fontSize=16;labelBackgroundColor=none;" parent="WkVDoU_EPi6P_C-XghKi-28" vertex="1" connectable="0">
           <mxGeometry x="0.3015" y="-2" relative="1" as="geometry">
-            <mxPoint x="8" y="18" as="offset" />
+            <mxPoint x="-25" y="-54" as="offset" />
           </mxGeometry>
         </mxCell>
       </root>

--- a/diagrams/ecosystemdetail.svg
+++ b/diagrams/ecosystemdetail.svg
@@ -1,257 +1,317 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-0.5 -0.5 903 590">
-    <rect width="125.25" height="58" x="20" y="321" fill="none" stroke="#000" pointer-events="all" rx="8.7" ry="8.7"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:123px;height:1px;padding-top:350px;margin-left:21px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <font>
-                            <span style="font-size:20px">
-                                Issuer
-                            </span>
-                        </font>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="83" y="355" font-family="Helvetica" font-size="16" text-anchor="middle">Issuer</text>
-    </switch>
-    <rect width="125.25" height="58" x="340" y="511" fill="none" stroke="#000" pointer-events="all" rx="8.7" ry="8.7"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:123px;height:1px;padding-top:540px;margin-left:341px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <font>
-                            <span style="font-size:20px">
-                                Registry
-                            </span>
-                        </font>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="403" y="545" font-family="Helvetica" font-size="16" text-anchor="middle">Registry</text>
-    </switch>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" d="m113.94 321 219.15-119.24" pointer-events="stroke"/>
-    <path stroke="#000" stroke-miterlimit="10" d="m339.02 198.53-5.76 8.26-.17-5.03-4.13-2.88Z" pointer-events="all"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:260px;margin-left:219px">
-                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
-                        <b>
-                            Issue
-                        </b>
-                        <br/>
-                        <font style="font-size:12px">
-                            exactly once
-                        </font>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="219" y="265" font-family="Helvetica" font-size="16" text-anchor="middle">Issue...</text>
-    </switch>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" d="m486.25 187 128.18 127.94" pointer-events="stroke"/>
-    <path stroke="#000" stroke-miterlimit="10" d="m619.21 319.71-9.55-3.17 4.77-1.6 1.59-4.77Z" pointer-events="all"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:255px;margin-left:555px">
-                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
-                        <b>
-                            Present
-                        </b>
-                        <br/>
-                        <font style="font-size:12px">
-                            repeatable
-                        </font>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="555" y="260" font-family="Helvetica" font-size="16" text-anchor="middle">Present...</text>
-    </switch>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" d="m620 335-466.89 14.75" pointer-events="stroke"/>
-    <path stroke="#000" stroke-miterlimit="10" d="m146.37 349.96 8.85-4.78-2.11 4.57 2.4 4.43Z" pointer-events="all"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:340px;margin-left:388px">
-                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
-                        <b>
-                            Check Status
-                            <br/>
-                        </b>
-                        <font style="font-size:12px">
-                            might NOT preserve privacy, repeatable
-                        </font>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="388" y="345" font-family="Helvetica" font-size="16" text-anchor="middle">Check Status...</text>
-    </switch>
-    <path fill="none" stroke="#000" stroke-dasharray="3 3" stroke-miterlimit="10" d="m113.94 379 219.65 156.44" pointer-events="stroke"/>
-    <path stroke="#000" stroke-miterlimit="10" d="m339.09 539.35-9.94-1.55 4.44-2.36.78-4.97Z" pointer-events="all"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:462px;margin-left:226px">
-                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
-                        <b>
-                            Revoke
-                            <br/>
-                        </b>
-                        <font style="font-size:12px">
-                            up to once
-                        </font>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="226" y="467" font-family="Helvetica" font-size="16" text-anchor="middle">Revoke...</text>
-    </switch>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" d="M620 349.5q-120 18.5-212.95 155" pointer-events="stroke"/>
-    <path stroke="#000" stroke-miterlimit="10" d="m403.25 510.08 1.35-9.98 2.45 4.4 4.99.67Z" pointer-events="all"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:412px;margin-left:492px">
-                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
-                        <b>
-                            Check Status
-                            <br/>
-                        </b>
-                        <font style="font-size:12px">
-                            MIGHT preserve privacy, repeatable
-                        </font>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="492" y="417" font-family="Helvetica" font-size="16" text-anchor="middle">Check Status...</text>
-    </switch>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" d="M682.31 396Q630 468 590 493t-117.13 45.02" pointer-events="stroke"/>
-    <path stroke="#000" stroke-miterlimit="10" d="m466.33 539.72 7.58-6.62-1.04 4.92 3.3 3.79Z" pointer-events="all"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:484px;margin-left:597px">
-                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
-                        <b>
-                            Verify
-                            <br/>
-                        </b>
-                        <font style="font-size:12px">
-                            repeatable
-                        </font>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="597" y="489" font-family="Helvetica" font-size="16" text-anchor="middle">Verify...</text>
-    </switch>
-    <circle cx="146.32" cy="64.32" r="16.315" fill="none" stroke="#000" stroke-width="6" pointer-events="all" transform="rotate(-35 146.32 64.32)"/>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="6" d="m132.951 73.68 26.73-18.715" pointer-events="all"/>
-    <path fill="none" stroke="#000" stroke-dasharray="3 3" stroke-miterlimit="10" d="M325 147 169.44 70.62" pointer-events="stroke"/>
-    <path stroke="#000" stroke-miterlimit="10" d="m163.39 67.64 10.06-.07-4.01 3.05.04 5.03Z" pointer-events="all"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:107px;margin-left:240px">
-                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
-                        <b>
-                            Delete
-                        </b>
-                        <br/>
-                        <font style="font-size:12px">
-                            up to once per Holder
-                        </font>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="240" y="111" font-family="Helvetica" font-size="16" text-anchor="middle">Delete...</text>
-    </switch>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" d="M400 126q30-100 55-105t45 15q20 20-16.57 102.8" pointer-events="stroke"/>
-    <path stroke="#000" stroke-miterlimit="10" d="m480.7 144.98-.48-10.05 3.21 3.87 5.02-.24Z" pointer-events="all"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:55px;margin-left:503px">
-                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
-                        <b>
-                            Transfer
-                        </b>
-                        <br/>
-                        <font style="font-size:12px">
-                            repeatable
-                        </font>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="503" y="59" font-family="Helvetica" font-size="16" text-anchor="middle">Transfer...</text>
-    </switch>
-    <rect width="125.25" height="58" x="651" y="338" fill="none" stroke="#000" pointer-events="all" rx="8.7" ry="8.7"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:123px;height:1px;padding-top:367px;margin-left:652px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <font>
-                            <span style="font-size:20px">
-                                Verifiers
-                            </span>
-                        </font>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="714" y="372" font-family="Helvetica" font-size="16" text-anchor="middle">Verifiers</text>
-    </switch>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" d="M650 387.01q-10 .99-10-4.51V338q0-10 5-10h120q5 0 5 10" pointer-events="stroke"/>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" d="M640 377q-10 1-10-4.5V328q0-10 5-10h120q5 0 5 10" pointer-events="stroke"/>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" d="M630 367q-10 1-10-4.5V318q0-10 5-10h120q5 0 5 10" pointer-events="stroke"/>
-    <rect width="125.25" height="58" x="361" y="158" fill="none" stroke="#000" pointer-events="all" rx="8.7" ry="8.7"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:123px;height:1px;padding-top:187px;margin-left:362px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <font>
-                            <span style="font-size:20px">
-                                Holders
-                            </span>
-                        </font>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="424" y="192" font-family="Helvetica" font-size="16" text-anchor="middle">Holders</text>
-    </switch>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" d="M360 207.01q-10 .99-10-4.51V158q0-10 5-10h120q5 0 5 10" pointer-events="stroke"/>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" d="M350 197q-10 1-10-4.5V148q0-10 5-10h120q5 0 5 10" pointer-events="stroke"/>
-    <path fill="none" stroke="#000" stroke-miterlimit="10" d="M340 187q-10 1-10-4.5V138q0-10 5-10h120q5 0 5 10M690 306q40-78 70-88t40 25q10 35-20.71 86.25" pointer-events="stroke"/>
-    <path stroke="#000" stroke-miterlimit="10" d="m775.82 335.04.77-10.03 2.7 4.24 5.02.38Z" pointer-events="all"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:265px;margin-left:807px">
-                <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;background-color:#fff;white-space:nowrap">
-                        <b>
-                            Verify and Validate
-                            <br/>
-                        </b>
-                        <font style="font-size:12px">
-                            repeatable
-                        </font>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="807" y="269" font-family="Helvetica" font-size="16" text-anchor="middle">Verify and Validate...</text>
-    </switch>
+<svg xmlns="http://www.w3.org/2000/svg" style="background:0 0;background-color:transparent;color-scheme:light" viewBox="-0.5 -0.5 870 633">
+    <g data-cell-id="0">
+        <g data-cell-id="1">
+            <g data-cell-id="r7VOtmBWi9sTdI5Oyx6i-1">
+                <rect width="125.25" height="58" x="20" y="364" fill="none" stroke="#000" pointer-events="all" rx="8.7" ry="8.7" style="stroke:#000"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:123px;height:1px;padding-top:393px;margin-left:21px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <font>
+                                        <span style="font-size:20px">
+                                            Issuer
+                                        </span>
+                                    </font>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="83" y="398" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">Issuer</text>
+                </switch>
+            </g>
+            <g data-cell-id="WkVDoU_EPi6P_C-XghKi-11">
+                <rect width="125.25" height="58" x="340" y="554" fill="none" stroke="#000" pointer-events="all" rx="8.7" ry="8.7" style="stroke:#000"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:123px;height:1px;padding-top:583px;margin-left:341px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <font>
+                                        <span style="font-size:20px">
+                                            Registry
+                                        </span>
+                                    </font>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="403" y="588" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">Registry</text>
+                </switch>
+            </g>
+            <g data-cell-id="WkVDoU_EPi6P_C-XghKi-12">
+                <g stroke="#000" stroke-miterlimit="10">
+                    <path fill="none" d="m113.94 364 219.15-119.24" pointer-events="stroke" style="stroke:#000"/>
+                    <path d="m339.02 241.53-5.76 8.26-.17-5.03-4.13-2.88Z" pointer-events="all" style="fill:#000;stroke:#000"/>
+                </g>
+                <switch data-cell-id="WkVDoU_EPi6P_C-XghKi-13" transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:281px;margin-left:199px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
+                                    <b>
+                                        Issue
+                                    </b>
+                                    <br/>
+                                    <font style="font-size:12px">
+                                        exactly once
+                                    </font>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="199" y="286" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">Issue...</text>
+                </switch>
+            </g>
+            <g data-cell-id="WkVDoU_EPi6P_C-XghKi-14">
+                <g stroke="#000" stroke-miterlimit="10">
+                    <path fill="none" d="m486.25 230 128.18 127.94" pointer-events="stroke" style="stroke:#000"/>
+                    <path d="m619.21 362.71-9.55-3.17 4.77-1.6 1.59-4.77Z" pointer-events="all" style="fill:#000;stroke:#000"/>
+                </g>
+                <switch data-cell-id="WkVDoU_EPi6P_C-XghKi-15" transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:281px;margin-left:591px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
+                                    <b>
+                                        Present
+                                    </b>
+                                    <br/>
+                                    <font style="font-size:12px">
+                                        repeatable
+                                    </font>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="591" y="286" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">Present...</text>
+                </switch>
+            </g>
+            <g data-cell-id="WkVDoU_EPi6P_C-XghKi-16">
+                <g stroke="#000" stroke-miterlimit="10">
+                    <path fill="none" d="m620 378-466.89 14.75" pointer-events="stroke" style="stroke:#000"/>
+                    <path d="m146.37 392.96 8.85-4.78-2.11 4.57 2.4 4.43Z" pointer-events="all" style="fill:#000;stroke:#000"/>
+                </g>
+                <switch data-cell-id="WkVDoU_EPi6P_C-XghKi-17" transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:362px;margin-left:321px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
+                                    <b>
+                                        Check Status
+                                        <br/>
+                                    </b>
+                                    <font style="font-size:12px">
+                                        might NOT preserve privacy, repeatable
+                                    </font>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="321" y="367" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">Check Status...</text>
+                </switch>
+            </g>
+            <g data-cell-id="WkVDoU_EPi6P_C-XghKi-18">
+                <g stroke="#000" stroke-miterlimit="10">
+                    <path fill="none" stroke-dasharray="3 3" d="m113.94 422 219.65 156.44" pointer-events="stroke" style="stroke:#000"/>
+                    <path d="m339.09 582.35-9.94-1.55 4.44-2.36.78-4.97Z" pointer-events="all" style="fill:#000;stroke:#000"/>
+                </g>
+                <switch data-cell-id="WkVDoU_EPi6P_C-XghKi-19" transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:555px;margin-left:244px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
+                                    <b>
+                                        Revoke
+                                        <br/>
+                                    </b>
+                                    <font style="font-size:12px">
+                                        up to once
+                                    </font>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="244" y="560" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">Revoke...</text>
+                </switch>
+            </g>
+            <g data-cell-id="WkVDoU_EPi6P_C-XghKi-20">
+                <g stroke="#000" stroke-miterlimit="10">
+                    <path fill="none" d="M620 392.5q-120 18.5-212.95 155" pointer-events="stroke" style="stroke:#000"/>
+                    <path d="m403.25 553.08 1.35-9.98 2.45 4.4 4.99.67Z" pointer-events="all" style="fill:#000;stroke:#000"/>
+                </g>
+                <switch data-cell-id="WkVDoU_EPi6P_C-XghKi-21" transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:461px;margin-left:404px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
+                                    <b>
+                                        Check Status
+                                        <br/>
+                                    </b>
+                                    <font style="font-size:12px">
+                                        MIGHT preserve privacy,
+                                    </font>
+                                    <div>
+                                        <font style="font-size:12px">
+                                            repeatable
+                                        </font>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="404" y="466" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">Check Status...</text>
+                </switch>
+            </g>
+            <g data-cell-id="WkVDoU_EPi6P_C-XghKi-23">
+                <g stroke="#000" stroke-miterlimit="10">
+                    <path fill="none" d="M682.31 439Q630 511 590 536t-117.13 45.02" pointer-events="stroke" style="stroke:#000"/>
+                    <path d="m466.33 582.72 7.58-6.62-1.04 4.92 3.3 3.79Z" pointer-events="all" style="fill:#000;stroke:#000"/>
+                </g>
+                <switch data-cell-id="WkVDoU_EPi6P_C-XghKi-24" transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:556px;margin-left:614px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
+                                    <b>
+                                        Verify
+                                        <br/>
+                                    </b>
+                                    <font style="font-size:12px">
+                                        repeatable
+                                    </font>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="614" y="561" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">Verify...</text>
+                </switch>
+            </g>
+            <g fill="none" stroke="#000" stroke-width="6" data-cell-id="WkVDoU_EPi6P_C-XghKi-30" pointer-events="all" transform="rotate(-35 128.93 127.32)">
+                <circle cx="128.93" cy="127.32" r="16.315" style="stroke:#000"/>
+                <path stroke-miterlimit="10" d="M112.62 127.32h32.63" style="stroke:#000"/>
+            </g>
+            <g data-cell-id="WkVDoU_EPi6P_C-XghKi-31">
+                <g stroke="#000" stroke-miterlimit="10">
+                    <path fill="none" stroke-dasharray="3 3" d="m325 190-172.53-57.37" pointer-events="stroke" style="stroke:#000"/>
+                    <path d="m146.06 130.5 9.96-1.43-3.55 3.56.71 4.98Z" pointer-events="all" style="fill:#000;stroke:#000"/>
+                </g>
+                <switch data-cell-id="WkVDoU_EPi6P_C-XghKi-32" transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:133px;margin-left:273px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
+                                    <b>
+                                        Delete
+                                    </b>
+                                    <br/>
+                                    <font style="font-size:12px">
+                                        up to once per Holder
+                                    </font>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="273" y="138" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">Delete...</text>
+                </switch>
+            </g>
+            <g data-cell-id="WkVDoU_EPi6P_C-XghKi-25">
+                <g stroke="#000" stroke-miterlimit="10">
+                    <path fill="none" d="M400 169q30-100 55-105t45 15q20 20-16.57 102.8" pointer-events="stroke" style="stroke:#000"/>
+                    <path d="m480.7 187.98-.48-10.05 3.21 3.87 5.02-.24Z" pointer-events="all" style="fill:#000;stroke:#000"/>
+                </g>
+                <switch data-cell-id="WkVDoU_EPi6P_C-XghKi-27" transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:39px;margin-left:471px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
+                                    <b>
+                                        Transfer
+                                    </b>
+                                    <br/>
+                                    <font style="font-size:12px">
+                                        repeatable
+                                    </font>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="471" y="43" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">Transfer...</text>
+                </switch>
+            </g>
+            <g data-cell-id="4crVNhUSypmRE79kbWuG-12">
+                <g data-cell-id="4crVNhUSypmRE79kbWuG-3">
+                    <rect width="125.25" height="58" x="651" y="381" fill="none" stroke="#000" pointer-events="all" rx="8.7" ry="8.7" style="stroke:#000"/>
+                    <switch transform="translate(-.5 -.5)">
+                        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:123px;height:1px;padding-top:410px;margin-left:652px">
+                                <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                    <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                        <font>
+                                            <span style="font-size:20px">
+                                                Verifiers
+                                            </span>
+                                        </font>
+                                    </div>
+                                </div>
+                            </div>
+                        </foreignObject>
+                        <text xmlns="http://www.w3.org/2000/svg" x="714" y="415" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">Verifiers</text>
+                    </switch>
+                </g>
+                <path fill="none" stroke="#000" stroke-miterlimit="10" d="M650 430.01q-10 .99-10-4.51V381q0-10 5-10h120q5 0 5 10" data-cell-id="4crVNhUSypmRE79kbWuG-9" pointer-events="stroke" style="stroke:#000"/>
+                <path fill="none" stroke="#000" stroke-miterlimit="10" d="M640 420q-10 1-10-4.5V371q0-10 5-10h120q5 0 5 10" data-cell-id="4crVNhUSypmRE79kbWuG-10" pointer-events="stroke" style="stroke:#000"/>
+                <path fill="none" stroke="#000" stroke-miterlimit="10" d="M630 410q-10 1-10-4.5V361q0-10 5-10h120q5 0 5 10" data-cell-id="4crVNhUSypmRE79kbWuG-11" pointer-events="stroke" style="stroke:#000"/>
+            </g>
+            <g data-cell-id="4crVNhUSypmRE79kbWuG-13">
+                <g data-cell-id="4crVNhUSypmRE79kbWuG-14">
+                    <rect width="125.25" height="58" x="361" y="201" fill="none" stroke="#000" pointer-events="all" rx="8.7" ry="8.7" style="stroke:#000"/>
+                    <switch transform="translate(-.5 -.5)">
+                        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:123px;height:1px;padding-top:230px;margin-left:362px">
+                                <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                    <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                        <font>
+                                            <span style="font-size:20px">
+                                                Holders
+                                            </span>
+                                        </font>
+                                    </div>
+                                </div>
+                            </div>
+                        </foreignObject>
+                        <text xmlns="http://www.w3.org/2000/svg" x="424" y="235" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">Holders</text>
+                    </switch>
+                </g>
+                <path fill="none" stroke="#000" stroke-miterlimit="10" d="M360 250.01q-10 .99-10-4.51V201q0-10 5-10h120q5 0 5 10" data-cell-id="4crVNhUSypmRE79kbWuG-15" pointer-events="stroke" style="stroke:#000"/>
+                <path fill="none" stroke="#000" stroke-miterlimit="10" d="M350 240q-10 1-10-4.5V191q0-10 5-10h120q5 0 5 10" data-cell-id="4crVNhUSypmRE79kbWuG-16" pointer-events="stroke" style="stroke:#000"/>
+                <path fill="none" stroke="#000" stroke-miterlimit="10" d="M340 230q-10 1-10-4.5V181q0-10 5-10h120q5 0 5 10" data-cell-id="4crVNhUSypmRE79kbWuG-17" pointer-events="stroke" style="stroke:#000"/>
+            </g>
+            <g data-cell-id="WkVDoU_EPi6P_C-XghKi-28">
+                <g stroke="#000" stroke-miterlimit="10">
+                    <path fill="none" d="M690 349q40-78 70-88t40 25q10 35-20.71 86.25" pointer-events="stroke" style="stroke:#000"/>
+                    <path d="m775.82 378.04.77-10.03 2.7 4.24 5.02.38Z" pointer-events="all" style="fill:#000;stroke:#000"/>
+                </g>
+                <switch data-cell-id="WkVDoU_EPi6P_C-XghKi-29" transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:1px;height:1px;padding-top:236px;margin-left:774px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:nowrap">
+                                    <b>
+                                        Verify and Validate
+                                        <br/>
+                                    </b>
+                                    <font style="font-size:12px">
+                                        repeatable
+                                    </font>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="774" y="240" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">Verify and Validate...</text>
+                </switch>
+            </g>
+        </g>
+    </g>
 </svg>

--- a/diagrams/presentation.drawio
+++ b/diagrams/presentation.drawio
@@ -1,29 +1,23 @@
-<mxfile host="Electron" modified="2024-03-13T08:57:31.494Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/24.0.4 Chrome/120.0.6099.109 Electron/28.1.0 Safari/537.36" etag="fmnAsIPzv1PYgucT5Ek-" version="24.0.4" type="device">
+<mxfile host="Electron" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/26.2.15 Chrome/134.0.6998.205 Electron/35.2.1 Safari/537.36" version="26.2.15">
   <diagram name="Page-1" id="ZRe_wIOORr0k_d4isBBX">
-    <mxGraphModel dx="2485" dy="1895" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
+    <mxGraphModel dx="2497" dy="1760" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
-        <mxCell id="I-3xDNqU13IutiKupr62-10" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;fontSize=12;startSize=8;endSize=8;" parent="1" edge="1">
-          <mxGeometry relative="1" as="geometry">
-            <mxPoint x="-1060" y="-519" as="sourcePoint" />
-            <mxPoint x="-1060" y="-519" as="targetPoint" />
-          </mxGeometry>
-        </mxCell>
         <mxCell id="NV7x72Zd9u3rbeVEopfi-3" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;" parent="1" vertex="1">
-          <mxGeometry x="-1010" y="-780" width="919.3600000000001" height="750" as="geometry" />
+          <mxGeometry x="-1042" y="-780" width="919.3600000000001" height="750" as="geometry" />
         </mxCell>
         <mxCell id="NV7x72Zd9u3rbeVEopfi-5" value="&lt;i&gt;&lt;b&gt;&lt;font style=&quot;font-size: 60px;&quot;&gt;Verifiable Presentation&lt;/font&gt;&lt;/b&gt;&lt;/i&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" parent="1" vertex="1">
-          <mxGeometry x="-901.1284210526316" y="-741.2903225806451" width="701.6168421052632" height="72.58064516129032" as="geometry" />
+          <mxGeometry x="-933.1284210526316" y="-741.2903225806451" width="701.6168421052632" height="72.58064516129032" as="geometry" />
         </mxCell>
         <mxCell id="CqYlGcgU1QHX9f7NfkNa-2" value="&lt;div&gt;&lt;font size=&quot;1&quot; style=&quot;&quot;&gt;&lt;i style=&quot;font-size: 60px;&quot;&gt;Presentation Metadata&lt;/i&gt;&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;strokeColor=#d21414;" parent="1" vertex="1">
-          <mxGeometry x="-901.1284210526316" y="-634.8387096774194" width="701.6168421052632" height="145.16129032258067" as="geometry" />
+          <mxGeometry x="-933.1284210526316" y="-634.8387096774194" width="701.6168421052632" height="145.16129032258067" as="geometry" />
         </mxCell>
         <mxCell id="NV7x72Zd9u3rbeVEopfi-1" value="&lt;div&gt;&lt;font size=&quot;1&quot; style=&quot;&quot;&gt;&lt;i style=&quot;font-size: 60px;&quot;&gt;Verifiable Credential(s)&lt;/i&gt;&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;strokeColor=#1b17d3;" parent="1" vertex="1">
-          <mxGeometry x="-901.1284210526316" y="-429.1935483870968" width="701.6168421052632" height="145.16129032258067" as="geometry" />
+          <mxGeometry x="-933.1284210526316" y="-429.1935483870968" width="701.6168421052632" height="145.16129032258067" as="geometry" />
         </mxCell>
         <mxCell id="NV7x72Zd9u3rbeVEopfi-2" value="&lt;div&gt;&lt;font size=&quot;1&quot; style=&quot;&quot;&gt;&lt;i style=&quot;font-size: 60px;&quot;&gt;Proof(s)&lt;/i&gt;&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;strokeColor=#146121;" parent="1" vertex="1">
-          <mxGeometry x="-901.1284210526316" y="-223.5483870967742" width="701.6168421052632" height="145.16129032258067" as="geometry" />
+          <mxGeometry x="-933.1284210526316" y="-223.5483870967742" width="701.6168421052632" height="145.16129032258067" as="geometry" />
         </mxCell>
       </root>
     </mxGraphModel>

--- a/diagrams/presentation.svg
+++ b/diagrams/presentation.svg
@@ -1,79 +1,91 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-0.5 -0.5 1021 793">
-    <rect width="919.36" height="750" x="79" y="21" fill="none" stroke="#000" stroke-width="3" pointer-events="all" rx="90" ry="90"/>
-    <rect width="701.62" height="72.58" x="187.87" y="59.71" fill="none" pointer-events="all"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:700px;height:1px;padding-top:96px;margin-left:189px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <i>
-                            <b>
-                                <font style="font-size:60px">
-                                    Verifiable Presentation
-                                </font>
-                            </b>
-                        </i>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="539" y="101" font-family="Helvetica" font-size="16" text-anchor="middle">Verifiable Presentation</text>
-    </switch>
-    <rect width="701.62" height="145.16" x="187.87" y="166.16" fill="none" stroke="#d21414" stroke-width="3" pointer-events="all" rx="21.77" ry="21.77"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:700px;height:1px;padding-top:239px;margin-left:189px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <div>
-                            <font size="1">
-                                <i style="font-size:60px">
-                                    Presentation Metadata
-                                </i>
-                            </font>
+<svg xmlns="http://www.w3.org/2000/svg" style="background:0 0;background-color:transparent;color-scheme:light" viewBox="-0.5 -0.5 963 793">
+    <g data-cell-id="0">
+        <g data-cell-id="1">
+            <rect width="919.36" height="750" x="21" y="21" fill="none" stroke="#000" stroke-width="3" data-cell-id="NV7x72Zd9u3rbeVEopfi-3" pointer-events="all" rx="90" ry="90" style="stroke:#000"/>
+            <g data-cell-id="NV7x72Zd9u3rbeVEopfi-5">
+                <rect width="701.62" height="72.58" x="129.87" y="59.71" fill="none" pointer-events="all"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:700px;height:1px;padding-top:96px;margin-left:131px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <i>
+                                        <b>
+                                            <font style="font-size:60px">
+                                                Verifiable Presentation
+                                            </font>
+                                        </b>
+                                    </i>
+                                </div>
+                            </div>
                         </div>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="539" y="242" font-family="Helvetica" font-size="12" text-anchor="middle">Presentation Metadata</text>
-    </switch>
-    <rect width="701.62" height="145.16" x="187.87" y="371.81" fill="none" stroke="#1b17d3" stroke-width="3" pointer-events="all" rx="21.77" ry="21.77"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:700px;height:1px;padding-top:444px;margin-left:189px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <div>
-                            <font size="1">
-                                <i style="font-size:60px">
-                                    Verifiable Credential(s)
-                                </i>
-                            </font>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="481" y="101" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">Verifiable Presentation</text>
+                </switch>
+            </g>
+            <g data-cell-id="CqYlGcgU1QHX9f7NfkNa-2">
+                <rect width="701.62" height="145.16" x="129.87" y="166.16" fill="none" stroke="#d21414" stroke-width="3" pointer-events="all" rx="21.77" ry="21.77" style="stroke:#d21414"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:700px;height:1px;padding-top:239px;margin-left:131px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:12px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <div>
+                                        <font size="1">
+                                            <i style="font-size:60px">
+                                                Presentation Metadata
+                                            </i>
+                                        </font>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="539" y="448" font-family="Helvetica" font-size="12" text-anchor="middle">Verifiable Credential(s)</text>
-    </switch>
-    <rect width="701.62" height="145.16" x="187.87" y="577.45" fill="none" stroke="#146121" stroke-width="3" pointer-events="all" rx="21.77" ry="21.77"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:700px;height:1px;padding-top:650px;margin-left:189px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <div>
-                            <font size="1">
-                                <i style="font-size:60px">
-                                    Proof(s)
-                                </i>
-                            </font>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="481" y="242" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12" text-anchor="middle">Presentation Metadata</text>
+                </switch>
+            </g>
+            <g data-cell-id="NV7x72Zd9u3rbeVEopfi-1">
+                <rect width="701.62" height="145.16" x="129.87" y="371.81" fill="none" stroke="#1b17d3" stroke-width="3" pointer-events="all" rx="21.77" ry="21.77" style="stroke:#1b17d3"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:700px;height:1px;padding-top:444px;margin-left:131px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:12px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <div>
+                                        <font size="1">
+                                            <i style="font-size:60px">
+                                                Verifiable Credential(s)
+                                            </i>
+                                        </font>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="539" y="654" font-family="Helvetica" font-size="12" text-anchor="middle">Proof(s)</text>
-    </switch>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="481" y="448" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12" text-anchor="middle">Verifiable Credential(s)</text>
+                </switch>
+            </g>
+            <g data-cell-id="NV7x72Zd9u3rbeVEopfi-2">
+                <rect width="701.62" height="145.16" x="129.87" y="577.45" fill="none" stroke="#146121" stroke-width="3" pointer-events="all" rx="21.77" ry="21.77" style="stroke:#146121"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:700px;height:1px;padding-top:650px;margin-left:131px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:12px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <div>
+                                        <font size="1">
+                                            <i style="font-size:60px">
+                                                Proof(s)
+                                            </i>
+                                        </font>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="481" y="654" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12" text-anchor="middle">Proof(s)</text>
+                </switch>
+            </g>
+        </g>
+    </g>
 </svg>

--- a/diagrams/vc.drawio
+++ b/diagrams/vc.drawio
@@ -1,29 +1,23 @@
-<mxfile host="Electron" modified="2024-03-13T09:01:25.685Z" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/24.0.4 Chrome/120.0.6099.109 Electron/28.1.0 Safari/537.36" etag="a1KS-VJ9tzcFpFGrsW_S" version="24.0.4" type="device">
+<mxfile host="Electron" agent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) draw.io/26.2.15 Chrome/134.0.6998.205 Electron/35.2.1 Safari/537.36" version="26.2.15">
   <diagram name="Page-1" id="ZRe_wIOORr0k_d4isBBX">
-    <mxGraphModel dx="2485" dy="1895" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
+    <mxGraphModel dx="2411" dy="1771" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1169" pageHeight="827" math="0" shadow="0">
       <root>
         <mxCell id="0" />
         <mxCell id="1" parent="0" />
-        <mxCell id="I-3xDNqU13IutiKupr62-10" style="edgeStyle=none;curved=1;rounded=0;orthogonalLoop=1;jettySize=auto;html=1;exitX=0;exitY=0.5;exitDx=0;exitDy=0;fontSize=12;startSize=8;endSize=8;" parent="1" edge="1">
-          <mxGeometry relative="1" as="geometry">
-            <mxPoint x="-1060" y="-519" as="sourcePoint" />
-            <mxPoint x="-1060" y="-519" as="targetPoint" />
-          </mxGeometry>
-        </mxCell>
         <mxCell id="NV7x72Zd9u3rbeVEopfi-3" value="" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;arcSize=12;" parent="1" vertex="1">
-          <mxGeometry x="-1010" y="-780" width="919.3600000000001" height="750" as="geometry" />
+          <mxGeometry x="-1044" y="-780" width="916.3600000000001" height="750" as="geometry" />
         </mxCell>
         <mxCell id="NV7x72Zd9u3rbeVEopfi-5" value="&lt;i&gt;&lt;b&gt;&lt;font style=&quot;font-size: 60px;&quot;&gt;Verifiable Credential&lt;/font&gt;&lt;/b&gt;&lt;/i&gt;" style="text;html=1;align=center;verticalAlign=middle;whiteSpace=wrap;rounded=0;fontSize=16;" parent="1" vertex="1">
-          <mxGeometry x="-901.1284210526316" y="-741.2903225806451" width="701.6168421052632" height="72.58064516129032" as="geometry" />
+          <mxGeometry x="-935.1284210526316" y="-741.2903225806451" width="698.6168421052632" height="72.58064516129032" as="geometry" />
         </mxCell>
         <mxCell id="CqYlGcgU1QHX9f7NfkNa-2" value="&lt;div&gt;&lt;font size=&quot;1&quot; style=&quot;&quot;&gt;&lt;i style=&quot;font-size: 60px;&quot;&gt;Credential Metadata&lt;/i&gt;&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;strokeColor=#D21414;" parent="1" vertex="1">
-          <mxGeometry x="-901.1284210526316" y="-634.8387096774194" width="701.6168421052632" height="145.16129032258067" as="geometry" />
+          <mxGeometry x="-935.1284210526316" y="-634.8387096774194" width="698.6168421052632" height="145.16129032258067" as="geometry" />
         </mxCell>
         <mxCell id="NV7x72Zd9u3rbeVEopfi-1" value="&lt;div&gt;&lt;font size=&quot;1&quot; style=&quot;&quot;&gt;&lt;i style=&quot;font-size: 60px;&quot;&gt;Claim(s)&lt;/i&gt;&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;strokeColor=#1b17d3;" parent="1" vertex="1">
-          <mxGeometry x="-901.1284210526316" y="-429.1935483870968" width="701.6168421052632" height="145.16129032258067" as="geometry" />
+          <mxGeometry x="-935.1284210526316" y="-429.1935483870968" width="698.6168421052632" height="145.16129032258067" as="geometry" />
         </mxCell>
         <mxCell id="NV7x72Zd9u3rbeVEopfi-2" value="&lt;div&gt;&lt;font size=&quot;1&quot; style=&quot;&quot;&gt;&lt;i style=&quot;font-size: 60px;&quot;&gt;Proof(s)&lt;/i&gt;&lt;/font&gt;&lt;/div&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=none;strokeWidth=3;strokeColor=#146121;" parent="1" vertex="1">
-          <mxGeometry x="-901.1284210526316" y="-223.5483870967742" width="701.6168421052632" height="145.16129032258067" as="geometry" />
+          <mxGeometry x="-935.1284210526316" y="-223.5483870967742" width="698.6168421052632" height="145.16129032258067" as="geometry" />
         </mxCell>
       </root>
     </mxGraphModel>

--- a/diagrams/vc.svg
+++ b/diagrams/vc.svg
@@ -1,79 +1,91 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-0.5 -0.5 1021 793">
-    <rect width="919.36" height="750" x="79" y="21" fill="none" stroke="#000" stroke-width="3" pointer-events="all" rx="90" ry="90"/>
-    <rect width="701.62" height="72.58" x="187.87" y="59.71" fill="none" pointer-events="all"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:700px;height:1px;padding-top:96px;margin-left:189px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:16px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <i>
-                            <b>
-                                <font style="font-size:60px">
-                                    Verifiable Credential
-                                </font>
-                            </b>
-                        </i>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="539" y="101" font-family="Helvetica" font-size="16" text-anchor="middle">Verifiable Credential</text>
-    </switch>
-    <rect width="701.62" height="145.16" x="187.87" y="166.16" fill="none" stroke="#d21414" stroke-width="3" pointer-events="all" rx="21.77" ry="21.77"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:700px;height:1px;padding-top:239px;margin-left:189px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <div>
-                            <font size="1">
-                                <i style="font-size:60px">
-                                    Credential Metadata
-                                </i>
-                            </font>
+<svg xmlns="http://www.w3.org/2000/svg" style="background:0 0;background-color:transparent;color-scheme:light" viewBox="-0.5 -0.5 960 793">
+    <g data-cell-id="0">
+        <g data-cell-id="1">
+            <rect width="916.36" height="750" x="21" y="21" fill="none" stroke="#000" stroke-width="3" data-cell-id="NV7x72Zd9u3rbeVEopfi-3" pointer-events="all" rx="90" ry="90" style="stroke:#000"/>
+            <g data-cell-id="NV7x72Zd9u3rbeVEopfi-5">
+                <rect width="698.62" height="72.58" x="129.87" y="59.71" fill="none" pointer-events="all"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:697px;height:1px;padding-top:96px;margin-left:131px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:16px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <i>
+                                        <b>
+                                            <font style="font-size:60px">
+                                                Verifiable Credential
+                                            </font>
+                                        </b>
+                                    </i>
+                                </div>
+                            </div>
                         </div>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="539" y="242" font-family="Helvetica" font-size="12" text-anchor="middle">Credential Metadata</text>
-    </switch>
-    <rect width="701.62" height="145.16" x="187.87" y="371.81" fill="none" stroke="#1b17d3" stroke-width="3" pointer-events="all" rx="21.77" ry="21.77"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:700px;height:1px;padding-top:444px;margin-left:189px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <div>
-                            <font size="1">
-                                <i style="font-size:60px">
-                                    Claim(s)
-                                </i>
-                            </font>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="479" y="101" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="16" text-anchor="middle">Verifiable Credential</text>
+                </switch>
+            </g>
+            <g data-cell-id="CqYlGcgU1QHX9f7NfkNa-2">
+                <rect width="698.62" height="145.16" x="129.87" y="166.16" fill="none" stroke="#d21414" stroke-width="3" pointer-events="all" rx="21.77" ry="21.77" style="stroke:#d21414"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:697px;height:1px;padding-top:239px;margin-left:131px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:12px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <div>
+                                        <font size="1">
+                                            <i style="font-size:60px">
+                                                Credential Metadata
+                                            </i>
+                                        </font>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="539" y="448" font-family="Helvetica" font-size="12" text-anchor="middle">Claim(s)</text>
-    </switch>
-    <rect width="701.62" height="145.16" x="187.87" y="577.45" fill="none" stroke="#146121" stroke-width="3" pointer-events="all" rx="21.77" ry="21.77"/>
-    <switch transform="translate(-.5 -.5)">
-        <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
-            <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:700px;height:1px;padding-top:650px;margin-left:189px">
-                <div data-drawio-colors="color: rgb(0, 0, 0);" style="box-sizing:border-box;font-size:0;text-align:center">
-                    <div style="display:inline-block;font-size:12px;font-family:Helvetica;color:#000;line-height:1.2;pointer-events:all;white-space:normal;overflow-wrap:normal">
-                        <div>
-                            <font size="1">
-                                <i style="font-size:60px">
-                                    Proof(s)
-                                </i>
-                            </font>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="479" y="242" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12" text-anchor="middle">Credential Metadata</text>
+                </switch>
+            </g>
+            <g data-cell-id="NV7x72Zd9u3rbeVEopfi-1">
+                <rect width="698.62" height="145.16" x="129.87" y="371.81" fill="none" stroke="#1b17d3" stroke-width="3" pointer-events="all" rx="21.77" ry="21.77" style="stroke:#1b17d3"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:697px;height:1px;padding-top:444px;margin-left:131px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:12px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <div>
+                                        <font size="1">
+                                            <i style="font-size:60px">
+                                                Claim(s)
+                                            </i>
+                                        </font>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
-                    </div>
-                </div>
-            </div>
-        </foreignObject>
-        <text xmlns="http://www.w3.org/2000/svg" x="539" y="654" font-family="Helvetica" font-size="12" text-anchor="middle">Proof(s)</text>
-    </switch>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="479" y="448" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12" text-anchor="middle">Claim(s)</text>
+                </switch>
+            </g>
+            <g data-cell-id="NV7x72Zd9u3rbeVEopfi-2">
+                <rect width="698.62" height="145.16" x="129.87" y="577.45" fill="none" stroke="#146121" stroke-width="3" pointer-events="all" rx="21.77" ry="21.77" style="stroke:#146121"/>
+                <switch transform="translate(-.5 -.5)">
+                    <foreignObject width="100%" height="100%" pointer-events="none" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow:visible;text-align:left">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display:flex;align-items:unsafe center;justify-content:unsafe center;width:697px;height:1px;padding-top:650px;margin-left:131px">
+                            <div style="box-sizing:border-box;font-size:0;text-align:center;color:#000">
+                                <div style="display:inline-block;font-size:12px;font-family:&quot;Helvetica&quot;;color:#000;line-height:1.2;pointer-events:all;white-space:normal;word-wrap:normal">
+                                    <div>
+                                        <font size="1">
+                                            <i style="font-size:60px">
+                                                Proof(s)
+                                            </i>
+                                        </font>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text xmlns="http://www.w3.org/2000/svg" x="479" y="654" fill="light-dark(#000000, #ffffff)" font-family="&quot;Helvetica&quot;" font-size="12" text-anchor="middle">Proof(s)</text>
+                </switch>
+            </g>
+        </g>
+    </g>
 </svg>

--- a/index.html
+++ b/index.html
@@ -236,6 +236,9 @@
         content: counters(numsection, ".") ") ";
       }
 
+      body.darkmode img {
+        background: hsl(52, 32%, 91%) ;
+      }
     </style>
   </head>
 


### PR DESCRIPTION
The W3C Dark mode sets the background for each image to white when the document is rendered in dark mode. That means a very large white spot on the black background, which is disagreeable. I have overwritten it with a slightly less flashy (pale yellow) color to make it easier on the eyes.

Unfortunately, this required modifications in a number of diagrams that used a white background on some elements.

Note that the automatic preview does not include the images, ie, the effects of the PR can be checked only by downloading the branch.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/vc-overview/pull/25.html" title="Last updated on May 7, 2025, 2:06 PM UTC (d9fe431)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/vc-overview/25/3b5ad03...d9fe431.html" title="Last updated on May 7, 2025, 2:06 PM UTC (d9fe431)">Diff</a>